### PR TITLE
修改Expander默认内容为占满宽度

### DIFF
--- a/src/Semi.Avalonia/Controls/Expander.axaml
+++ b/src/Semi.Avalonia/Controls/Expander.axaml
@@ -23,7 +23,7 @@
         <Setter Property="Expander.BorderBrush" Value="{DynamicResource ExpanderSeparatorBorderBrush}" />
         <Setter Property="Expander.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Expander.HorizontalAlignment" Value="Stretch" />
-        <Setter Property="Expander.HorizontalContentAlignment" Value="Left" />
+        <Setter Property="Expander.HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="Expander.VerticalContentAlignment" Value="Stretch" />
         <Setter Property="Expander.Template">
             <ControlTemplate TargetType="Expander">


### PR DESCRIPTION
Expander本身已经占满了可用宽度，但其内容却是Left