### PR TITLE
Make DataGrid group header customizable

### DIFF
--- a/src/Semi.Avalonia.DataGrid/DataGrid.axaml
+++ b/src/Semi.Avalonia.DataGrid/DataGrid.axaml
@@ -406,10 +406,11 @@
                             Margin="4,0,0,0"
                             Foreground="{TemplateBinding Foreground}"
                             IsVisible="{TemplateBinding IsPropertyNameVisible}" />
-                        <TextBlock
+                        <ContentControl
+                            Name="PART_GroupKeyContentControl"
                             Margin="4,0,0,0"
                             Foreground="{TemplateBinding Foreground}"
-                            Text="{Binding Key}" />
+                            Content="{Binding Key}" />
                         <TextBlock
                             Name="PART_ItemCountElement"
                             Margin="4,0,0,0"


### PR DESCRIPTION
Use ContentControl to display GroupKey. now user is able to customize how Groupkey is displayed. 

```xaml
                <DataGrid.Styles>
                    <Style Selector="DataGridRowGroupHeader /template/ ContentControl#PART_GroupKeyContentControl">
                        <Setter Property="ContentTemplate">
                            <DataTemplate DataType="x:String"> <!-- the typeof your grouping key-->
                                <TextBlock Text="{Binding}" Foreground="Red"></TextBlock>
                            </DataTemplate>
                        </Setter>
                    </Style>
                </DataGrid.Styles>
```