### PR TITLE
bugfix:Demo crashes when changing SplitView's PanePlacement

### DIFF
--- a/demo/Semi.Avalonia.Demo/Themes/ToggleSwitch.axaml
+++ b/demo/Semi.Avalonia.Demo/Themes/ToggleSwitch.axaml
@@ -3,11 +3,13 @@
                   BasedOn="{StaticResource ButtonToggleSwitch}"
                   TargetType="ToggleSwitch">
         <Setter Property="Padding" Value="8" />
+        <Setter Property="OnContent" Value="{Binding $self.Content}" />
         <Setter Property="OnContentTemplate">
             <DataTemplate>
                 <PathIcon Theme="{StaticResource InnerPathIcon}" Data="{Binding}" />
             </DataTemplate>
         </Setter>
+        <Setter Property="OffContent" Value="{Binding $self.Content}" />
         <Setter Property="OffContentTemplate">
             <DataTemplate>
                 <PathIcon Theme="{StaticResource InnerPathIcon}" Data="{Binding}" />


### PR DESCRIPTION
#485 
最终找到的问题原因：
在切换时，`OnContent`会瞬间有值`On`、`OffContent`会瞬间有值`Off`，这两个值被***PathIcon***的`Data`拿到之后就会报错。
解决办法：
将这两个绑定到`Content`就可以避免这个问题。