### PR TITLE
feat: ComboBox should respect SelectionBoxItemTemplate

### DIFF
--- a/demo/Semi.Avalonia.Demo/Pages/ComboBoxDemo.axaml
+++ b/demo/Semi.Avalonia.Demo/Pages/ComboBoxDemo.axaml
@@ -27,6 +27,15 @@
         <ComboBox Classes="Small" />
         <ComboBox Classes="Bordered" />
         <ComboBox Classes="Bordered" IsEnabled="False" />
+        <ComboBox>
+          <ComboBox.SelectionBoxItemTemplate>
+            <DataTemplate DataType="x:String">
+              <ContentControl BorderThickness="1"
+                              BorderBrush="Gold"
+                              Content="{Binding}" />
+            </DataTemplate>
+          </ComboBox.SelectionBoxItemTemplate>
+        </ComboBox>
 
         <StackPanel Orientation="Horizontal">
             <ComboBox Width="100" Classes="Large" PlaceholderText="Large" />

--- a/src/Semi.Avalonia/Controls/ComboBox.axaml
+++ b/src/Semi.Avalonia/Controls/ComboBox.axaml
@@ -76,7 +76,7 @@
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                             Content="{TemplateBinding SelectionBoxItem}"
-                            ContentTemplate="{TemplateBinding ItemTemplate}" />
+                            ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" />
                         <Button
                             Name="ClearButton"
                             Grid.Column="1"


### PR DESCRIPTION
AvaloniaUI/Avalonia#15420 introduced a new property `SelectionBoxItemTemplate`, which allows setting a different data template for the selected item within a ComboBox selection box compared to the items in the dropdown.

---

This pull request tries to make this property respected. The demo has also been updated with a new instance to demonstrate this capability.

---

![image](https://github.com/user-attachments/assets/627e611c-8a12-402e-bd8e-924f6b962a5b)



