### PR TITLE
fix: 修复ComboBox控件的PlaceholderForeground属性失效

### DIFF
--- a/src/Semi.Avalonia/Controls/ComboBox.axaml
+++ b/src/Semi.Avalonia/Controls/ComboBox.axaml
@@ -68,7 +68,6 @@
                             TextTrimming="CharacterEllipsis"
                             Foreground="{TemplateBinding PlaceholderForeground}"
                             IsVisible="{TemplateBinding SelectionBoxItem,Converter={x:Static ObjectConverters.IsNull}}"
-                            Opacity="0.3"
                             Text="{TemplateBinding PlaceholderText}" />
                         <ContentPresenter
                             Name="ContentPresenter"

--- a/src/Semi.Avalonia/Controls/ComboBox.axaml
+++ b/src/Semi.Avalonia/Controls/ComboBox.axaml
@@ -12,7 +12,7 @@
                 <ComboBoxItem>BBB</ComboBoxItem>
                 <ComboBoxItem>CCC</ComboBoxItem>
             </ComboBox>
-            <ComboBox Width="100" PlaceholderText="Select">
+            <ComboBox Width="100" PlaceholderText="Select" PlaceholderForeground="Red">
                 <ComboBoxItem>AAA</ComboBoxItem>
                 <ComboBoxItem>BBB</ComboBoxItem>
                 <ComboBoxItem>CCC</ComboBoxItem>
@@ -44,6 +44,7 @@
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="MinHeight" Value="{DynamicResource ComboBoxDefaultHeight}" />
+        <Setter Property="PlaceholderForeground" Value="{DynamicResource ComboBoxSelectorPlaceHolderForeground}"/>
         <Setter Property="Template">
             <ControlTemplate TargetType="ComboBox">
                 <DataValidationErrors>
@@ -65,7 +66,7 @@
                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             TextTrimming="CharacterEllipsis"
-                            Foreground="{TemplateBinding Foreground}"
+                            Foreground="{TemplateBinding PlaceholderForeground}"
                             IsVisible="{TemplateBinding SelectionBoxItem,Converter={x:Static ObjectConverters.IsNull}}"
                             Opacity="0.3"
                             Text="{TemplateBinding PlaceholderText}" />

--- a/src/Semi.Avalonia/Themes/Dark/ComboBox.axaml
+++ b/src/Semi.Avalonia/Themes/Dark/ComboBox.axaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <StaticResource x:Key="ComboBoxSelectorBackground" ResourceKey="SemiColorFill0" />
+    <StaticResource x:Key="ComboBoxSelectorPlaceHolderForeground" ResourceKey="SemiColorText0" />
     <StaticResource x:Key="ComboBoxSelectorPointeroverBackground" ResourceKey="SemiColorFill1" />
     <StaticResource x:Key="ComboBoxSelectorFocusBackground" ResourceKey="SemiColorFill1" />
     <StaticResource x:Key="ComboBoxSelectorPressedBackground" ResourceKey="SemiColorFill2" />

--- a/src/Semi.Avalonia/Themes/Dark/ComboBox.axaml
+++ b/src/Semi.Avalonia/Themes/Dark/ComboBox.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <StaticResource x:Key="ComboBoxSelectorBackground" ResourceKey="SemiColorFill0" />
-    <StaticResource x:Key="ComboBoxSelectorPlaceHolderForeground" ResourceKey="SemiColorText0" />
+    <StaticResource x:Key="ComboBoxSelectorPlaceHolderForeground" ResourceKey="SemiColorText2" />
     <StaticResource x:Key="ComboBoxSelectorPointeroverBackground" ResourceKey="SemiColorFill1" />
     <StaticResource x:Key="ComboBoxSelectorFocusBackground" ResourceKey="SemiColorFill1" />
     <StaticResource x:Key="ComboBoxSelectorPressedBackground" ResourceKey="SemiColorFill2" />

--- a/src/Semi.Avalonia/Themes/HighContrast/ComboBox.axaml
+++ b/src/Semi.Avalonia/Themes/HighContrast/ComboBox.axaml
@@ -1,34 +1,33 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <StaticResource x:Key="ComboBoxSelectorBackground" ResourceKey="SemiColorWindow"/>
-    <StaticResource x:Key="ComboBoxSelectorPlaceHolderForeground" ResourceKey="SemiColorText2"/>
-    <StaticResource x:Key="ComboBoxSelectorPointeroverBackground" ResourceKey="SemiColorHighlightText"/>
-    <StaticResource x:Key="ComboBoxSelectorFocusBackground" ResourceKey="SemiColorWindow"/>
-    <StaticResource x:Key="ComboBoxSelectorPressedBackground" ResourceKey="SemiColorHighlightText"/>
-    <StaticResource x:Key="ComboBoxSelectorDisabledBackground" ResourceKey="SemiColorWindow"/>
-    <StaticResource x:Key="ComboBoxSelectorDisabledBorderBrush" ResourceKey="SemiColorGrayText"/>
-    <StaticResource x:Key="ComboBoxSelectorBorderBrush" ResourceKey="SemiColorButtonText"/>
-    <StaticResource x:Key="ComboBoxSelectorPointeroverBorderBrush" ResourceKey="SemiColorHighlight"/>
-    <StaticResource x:Key="ComboBoxSelectorFocusBorderBrush" ResourceKey="SemiColorHighlight"/>
-    <StaticResource x:Key="ComboBoxSelectorPressedBorderBrush" ResourceKey="SemiColorHighlight"/>
-    <StaticResource x:Key="ComboBoxIconDefaultForeground" ResourceKey="SemiColorButtonText"/>
-    <StaticResource x:Key="ComboBoxIconPointeroverForeground" ResourceKey="SemiColorButtonText"/>
-    <StaticResource x:Key="ComboBoxIconFocusForeground" ResourceKey="SemiColorButtonText"/>
-    <StaticResource x:Key="ComboBoxIconPressedForeground" ResourceKey="SemiColorButtonText"/>
-    <StaticResource x:Key="ComboBoxIconDisabledForeground" ResourceKey="SemiColorGrayText"/>
-    <StaticResource x:Key="ComboBoxDisabledForeground" ResourceKey="SemiColorGrayText"/>
-    <StaticResource x:Key="ComboBoxPopupBackground" ResourceKey="SemiColorWindow"/>
-    <StaticResource x:Key="ComboBoxPopupBorderBrush" ResourceKey="SemiColorButtonText"/>
-    <StaticResource x:Key="ComboBoxItemForeground" ResourceKey="SemiColorWindowText"/>
-    <StaticResource x:Key="ComboBoxItemBackground" ResourceKey="SemiColorWindow"/>
-    <StaticResource x:Key="ComboBoxItemPointeroverForeground" ResourceKey="SemiColorHighlightText"/>
-    <StaticResource x:Key="ComboBoxItemPointeroverBackground" ResourceKey="SemiColorHighlight"/>
-    <StaticResource x:Key="ComboBoxItemFocusForeground" ResourceKey="SemiColorHighlightText"/>
-    <StaticResource x:Key="ComboBoxItemFocusBackground" ResourceKey="SemiColorHighlight"/>
-    <StaticResource x:Key="ComboBoxItemPressedForeground" ResourceKey="SemiColorHighlightText"/>
-    <StaticResource x:Key="ComboBoxItemPressedBackground" ResourceKey="SemiColorHighlight"/>
-    <StaticResource x:Key="ComboBoxItemSelectedForeground" ResourceKey="SemiColorHighlightText"/>
-    <StaticResource x:Key="ComboBoxItemSelectedBackground" ResourceKey="SemiColorHighlight"/>
-    <StaticResource x:Key="ComboBoxItemSelectedPointeroverBackground" ResourceKey="SemiColorHighlight"/>
-    <StaticResource x:Key="ComboBoxItemDisabledBackground" ResourceKey="SemiColorWindow"/>
-    <StaticResource x:Key="ComboBoxItemSelectedDisabledBackground" ResourceKey="SemiColorWindow"/>
+    <StaticResource x:Key="ComboBoxSelectorBackground" ResourceKey="SemiColorWindow" />
+    <StaticResource x:Key="ComboBoxSelectorPointeroverBackground" ResourceKey="SemiColorHighlightText" />
+    <StaticResource x:Key="ComboBoxSelectorFocusBackground" ResourceKey="SemiColorWindow" />
+    <StaticResource x:Key="ComboBoxSelectorPressedBackground" ResourceKey="SemiColorHighlightText" />
+    <StaticResource x:Key="ComboBoxSelectorDisabledBackground" ResourceKey="SemiColorWindow" />
+    <StaticResource x:Key="ComboBoxSelectorDisabledBorderBrush" ResourceKey="SemiColorGrayText" />
+    <StaticResource x:Key="ComboBoxSelectorBorderBrush" ResourceKey="SemiColorButtonText" />
+    <StaticResource x:Key="ComboBoxSelectorPointeroverBorderBrush" ResourceKey="SemiColorHighlight" />
+    <StaticResource x:Key="ComboBoxSelectorFocusBorderBrush" ResourceKey="SemiColorHighlight" />
+    <StaticResource x:Key="ComboBoxSelectorPressedBorderBrush" ResourceKey="SemiColorHighlight" />
+    <StaticResource x:Key="ComboBoxIconDefaultForeground" ResourceKey="SemiColorButtonText" />
+    <StaticResource x:Key="ComboBoxIconPointeroverForeground" ResourceKey="SemiColorButtonText" />
+    <StaticResource x:Key="ComboBoxIconFocusForeground" ResourceKey="SemiColorButtonText" />
+    <StaticResource x:Key="ComboBoxIconPressedForeground" ResourceKey="SemiColorButtonText" />
+    <StaticResource x:Key="ComboBoxIconDisabledForeground" ResourceKey="SemiColorGrayText" />
+    <StaticResource x:Key="ComboBoxDisabledForeground" ResourceKey="SemiColorGrayText" />
+    <StaticResource x:Key="ComboBoxPopupBackground" ResourceKey="SemiColorWindow" />
+    <StaticResource x:Key="ComboBoxPopupBorderBrush" ResourceKey="SemiColorButtonText" />
+    <StaticResource x:Key="ComboBoxItemForeground" ResourceKey="SemiColorWindowText" />
+    <StaticResource x:Key="ComboBoxItemBackground" ResourceKey="SemiColorWindow" />
+    <StaticResource x:Key="ComboBoxItemPointeroverForeground" ResourceKey="SemiColorHighlightText" />
+    <StaticResource x:Key="ComboBoxItemPointeroverBackground" ResourceKey="SemiColorHighlight" />
+    <StaticResource x:Key="ComboBoxItemFocusForeground" ResourceKey="SemiColorHighlightText" />
+    <StaticResource x:Key="ComboBoxItemFocusBackground" ResourceKey="SemiColorHighlight" />
+    <StaticResource x:Key="ComboBoxItemPressedForeground" ResourceKey="SemiColorHighlightText" />
+    <StaticResource x:Key="ComboBoxItemPressedBackground" ResourceKey="SemiColorHighlight" />
+    <StaticResource x:Key="ComboBoxItemSelectedForeground" ResourceKey="SemiColorHighlightText" />
+    <StaticResource x:Key="ComboBoxItemSelectedBackground" ResourceKey="SemiColorHighlight" />
+    <StaticResource x:Key="ComboBoxItemSelectedPointeroverBackground" ResourceKey="SemiColorHighlight" />
+    <StaticResource x:Key="ComboBoxItemDisabledBackground" ResourceKey="SemiColorWindow" />
+    <StaticResource x:Key="ComboBoxItemSelectedDisabledBackground" ResourceKey="SemiColorWindow" />
 </ResourceDictionary>

--- a/src/Semi.Avalonia/Themes/HighContrast/ComboBox.axaml
+++ b/src/Semi.Avalonia/Themes/HighContrast/ComboBox.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <StaticResource x:Key="ComboBoxSelectorBackground" ResourceKey="SemiColorWindow" />
-    <StaticResource x:Key="ComboBoxSelectorPlaceHolderForeground" ResourceKey="SemiColorText2"/>
+    <StaticResource x:Key="ComboBoxSelectorPlaceHolderForeground" ResourceKey="SemiColorGrayText" />
     <StaticResource x:Key="ComboBoxSelectorPointeroverBackground" ResourceKey="SemiColorHighlightText" />
     <StaticResource x:Key="ComboBoxSelectorFocusBackground" ResourceKey="SemiColorWindow" />
     <StaticResource x:Key="ComboBoxSelectorPressedBackground" ResourceKey="SemiColorHighlightText" />

--- a/src/Semi.Avalonia/Themes/HighContrast/ComboBox.axaml
+++ b/src/Semi.Avalonia/Themes/HighContrast/ComboBox.axaml
@@ -1,33 +1,34 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <StaticResource x:Key="ComboBoxSelectorBackground" ResourceKey="SemiColorWindow" />
-    <StaticResource x:Key="ComboBoxSelectorPointeroverBackground" ResourceKey="SemiColorHighlightText" />
-    <StaticResource x:Key="ComboBoxSelectorFocusBackground" ResourceKey="SemiColorWindow" />
-    <StaticResource x:Key="ComboBoxSelectorPressedBackground" ResourceKey="SemiColorHighlightText" />
-    <StaticResource x:Key="ComboBoxSelectorDisabledBackground" ResourceKey="SemiColorWindow" />
-    <StaticResource x:Key="ComboBoxSelectorDisabledBorderBrush" ResourceKey="SemiColorGrayText" />
-    <StaticResource x:Key="ComboBoxSelectorBorderBrush" ResourceKey="SemiColorButtonText" />
-    <StaticResource x:Key="ComboBoxSelectorPointeroverBorderBrush" ResourceKey="SemiColorHighlight" />
-    <StaticResource x:Key="ComboBoxSelectorFocusBorderBrush" ResourceKey="SemiColorHighlight" />
-    <StaticResource x:Key="ComboBoxSelectorPressedBorderBrush" ResourceKey="SemiColorHighlight" />
-    <StaticResource x:Key="ComboBoxIconDefaultForeground" ResourceKey="SemiColorButtonText" />
-    <StaticResource x:Key="ComboBoxIconPointeroverForeground" ResourceKey="SemiColorButtonText" />
-    <StaticResource x:Key="ComboBoxIconFocusForeground" ResourceKey="SemiColorButtonText" />
-    <StaticResource x:Key="ComboBoxIconPressedForeground" ResourceKey="SemiColorButtonText" />
-    <StaticResource x:Key="ComboBoxIconDisabledForeground" ResourceKey="SemiColorGrayText" />
-    <StaticResource x:Key="ComboBoxDisabledForeground" ResourceKey="SemiColorGrayText" />
-    <StaticResource x:Key="ComboBoxPopupBackground" ResourceKey="SemiColorWindow" />
-    <StaticResource x:Key="ComboBoxPopupBorderBrush" ResourceKey="SemiColorButtonText" />
-    <StaticResource x:Key="ComboBoxItemForeground" ResourceKey="SemiColorWindowText" />
-    <StaticResource x:Key="ComboBoxItemBackground" ResourceKey="SemiColorWindow" />
-    <StaticResource x:Key="ComboBoxItemPointeroverForeground" ResourceKey="SemiColorHighlightText" />
-    <StaticResource x:Key="ComboBoxItemPointeroverBackground" ResourceKey="SemiColorHighlight" />
-    <StaticResource x:Key="ComboBoxItemFocusForeground" ResourceKey="SemiColorHighlightText" />
-    <StaticResource x:Key="ComboBoxItemFocusBackground" ResourceKey="SemiColorHighlight" />
-    <StaticResource x:Key="ComboBoxItemPressedForeground" ResourceKey="SemiColorHighlightText" />
-    <StaticResource x:Key="ComboBoxItemPressedBackground" ResourceKey="SemiColorHighlight" />
-    <StaticResource x:Key="ComboBoxItemSelectedForeground" ResourceKey="SemiColorHighlightText" />
-    <StaticResource x:Key="ComboBoxItemSelectedBackground" ResourceKey="SemiColorHighlight" />
-    <StaticResource x:Key="ComboBoxItemSelectedPointeroverBackground" ResourceKey="SemiColorHighlight" />
-    <StaticResource x:Key="ComboBoxItemDisabledBackground" ResourceKey="SemiColorWindow" />
-    <StaticResource x:Key="ComboBoxItemSelectedDisabledBackground" ResourceKey="SemiColorWindow" />
+    <StaticResource x:Key="ComboBoxSelectorBackground" ResourceKey="SemiColorWindow"/>
+    <StaticResource x:Key="ComboBoxSelectorPlaceHolderForeground" ResourceKey="SemiColorText2"/>
+    <StaticResource x:Key="ComboBoxSelectorPointeroverBackground" ResourceKey="SemiColorHighlightText"/>
+    <StaticResource x:Key="ComboBoxSelectorFocusBackground" ResourceKey="SemiColorWindow"/>
+    <StaticResource x:Key="ComboBoxSelectorPressedBackground" ResourceKey="SemiColorHighlightText"/>
+    <StaticResource x:Key="ComboBoxSelectorDisabledBackground" ResourceKey="SemiColorWindow"/>
+    <StaticResource x:Key="ComboBoxSelectorDisabledBorderBrush" ResourceKey="SemiColorGrayText"/>
+    <StaticResource x:Key="ComboBoxSelectorBorderBrush" ResourceKey="SemiColorButtonText"/>
+    <StaticResource x:Key="ComboBoxSelectorPointeroverBorderBrush" ResourceKey="SemiColorHighlight"/>
+    <StaticResource x:Key="ComboBoxSelectorFocusBorderBrush" ResourceKey="SemiColorHighlight"/>
+    <StaticResource x:Key="ComboBoxSelectorPressedBorderBrush" ResourceKey="SemiColorHighlight"/>
+    <StaticResource x:Key="ComboBoxIconDefaultForeground" ResourceKey="SemiColorButtonText"/>
+    <StaticResource x:Key="ComboBoxIconPointeroverForeground" ResourceKey="SemiColorButtonText"/>
+    <StaticResource x:Key="ComboBoxIconFocusForeground" ResourceKey="SemiColorButtonText"/>
+    <StaticResource x:Key="ComboBoxIconPressedForeground" ResourceKey="SemiColorButtonText"/>
+    <StaticResource x:Key="ComboBoxIconDisabledForeground" ResourceKey="SemiColorGrayText"/>
+    <StaticResource x:Key="ComboBoxDisabledForeground" ResourceKey="SemiColorGrayText"/>
+    <StaticResource x:Key="ComboBoxPopupBackground" ResourceKey="SemiColorWindow"/>
+    <StaticResource x:Key="ComboBoxPopupBorderBrush" ResourceKey="SemiColorButtonText"/>
+    <StaticResource x:Key="ComboBoxItemForeground" ResourceKey="SemiColorWindowText"/>
+    <StaticResource x:Key="ComboBoxItemBackground" ResourceKey="SemiColorWindow"/>
+    <StaticResource x:Key="ComboBoxItemPointeroverForeground" ResourceKey="SemiColorHighlightText"/>
+    <StaticResource x:Key="ComboBoxItemPointeroverBackground" ResourceKey="SemiColorHighlight"/>
+    <StaticResource x:Key="ComboBoxItemFocusForeground" ResourceKey="SemiColorHighlightText"/>
+    <StaticResource x:Key="ComboBoxItemFocusBackground" ResourceKey="SemiColorHighlight"/>
+    <StaticResource x:Key="ComboBoxItemPressedForeground" ResourceKey="SemiColorHighlightText"/>
+    <StaticResource x:Key="ComboBoxItemPressedBackground" ResourceKey="SemiColorHighlight"/>
+    <StaticResource x:Key="ComboBoxItemSelectedForeground" ResourceKey="SemiColorHighlightText"/>
+    <StaticResource x:Key="ComboBoxItemSelectedBackground" ResourceKey="SemiColorHighlight"/>
+    <StaticResource x:Key="ComboBoxItemSelectedPointeroverBackground" ResourceKey="SemiColorHighlight"/>
+    <StaticResource x:Key="ComboBoxItemDisabledBackground" ResourceKey="SemiColorWindow"/>
+    <StaticResource x:Key="ComboBoxItemSelectedDisabledBackground" ResourceKey="SemiColorWindow"/>
 </ResourceDictionary>

--- a/src/Semi.Avalonia/Themes/HighContrast/ComboBox.axaml
+++ b/src/Semi.Avalonia/Themes/HighContrast/ComboBox.axaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <StaticResource x:Key="ComboBoxSelectorBackground" ResourceKey="SemiColorWindow" />
+    <StaticResource x:Key="ComboBoxSelectorPlaceHolderForeground" ResourceKey="SemiColorText2"/>
     <StaticResource x:Key="ComboBoxSelectorPointeroverBackground" ResourceKey="SemiColorHighlightText" />
     <StaticResource x:Key="ComboBoxSelectorFocusBackground" ResourceKey="SemiColorWindow" />
     <StaticResource x:Key="ComboBoxSelectorPressedBackground" ResourceKey="SemiColorHighlightText" />

--- a/src/Semi.Avalonia/Themes/Light/ComboBox.axaml
+++ b/src/Semi.Avalonia/Themes/Light/ComboBox.axaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <StaticResource x:Key="ComboBoxSelectorBackground" ResourceKey="SemiColorFill0" />
+    <StaticResource x:Key="ComboBoxSelectorPlaceHolderForeground" ResourceKey="SemiColorText0" />
     <StaticResource x:Key="ComboBoxSelectorPointeroverBackground" ResourceKey="SemiColorFill1" />
     <StaticResource x:Key="ComboBoxSelectorFocusBackground" ResourceKey="SemiColorFill1" />
     <StaticResource x:Key="ComboBoxSelectorPressedBackground" ResourceKey="SemiColorFill2" />

--- a/src/Semi.Avalonia/Themes/Light/ComboBox.axaml
+++ b/src/Semi.Avalonia/Themes/Light/ComboBox.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <StaticResource x:Key="ComboBoxSelectorBackground" ResourceKey="SemiColorFill0" />
-    <StaticResource x:Key="ComboBoxSelectorPlaceHolderForeground" ResourceKey="SemiColorText0" />
+    <StaticResource x:Key="ComboBoxSelectorPlaceHolderForeground" ResourceKey="SemiColorText2" />
     <StaticResource x:Key="ComboBoxSelectorPointeroverBackground" ResourceKey="SemiColorFill1" />
     <StaticResource x:Key="ComboBoxSelectorFocusBackground" ResourceKey="SemiColorFill1" />
     <StaticResource x:Key="ComboBoxSelectorPressedBackground" ResourceKey="SemiColorFill2" />


### PR DESCRIPTION
ComboBox控件尝试使用PlaceholderForeground属性,发现失效
查Semi.Avalonia源码ComboBox没有PlaceholderForeground属性了, 而Template中把PlaceholderTextBlock的Foreground作为了PlaceholderForeground,但是这就没有达到预期,选中ComboBoxItem后颜色没有恢复(直接使用Foreground属性)

```axml
            <ComboBox Width="100" PlaceholderText="Select" PlaceholderForeground="Red">
                <ComboBoxItem>AAA</ComboBoxItem>
                <ComboBoxItem>BBB</ComboBoxItem>
                <ComboBoxItem>CCC</ComboBoxItem>
            </ComboBox>
```
此次PR修复后效果
选中前
![image](https://github.com/user-attachments/assets/9f10a20e-696b-40e8-a951-47ec3ca0a5a2)
选中后
![image](https://github.com/user-attachments/assets/b75c3ec6-6010-4860-9680-0c595b53b70c)

第一次提PR, 兔佬帮忙Review一下,感谢
@rabbitism 