### PR TITLE
ScrollBar Update

### DIFF
--- a/demo/Semi.Avalonia.Demo/Pages/DataGridDemo.axaml
+++ b/demo/Semi.Avalonia.Demo/Pages/DataGridDemo.axaml
@@ -15,8 +15,9 @@
         <TabItem Header="DataGrid">
            <Grid RowDefinitions="Auto, *">
                <StackPanel Grid.Row="0" Orientation="Horizontal">
-                   <ToggleSwitch Content="Disable" Name="DisableToggle" />
-                   <ToggleSwitch Content="ScrollViewerHide" Name="ScrollViewerHide" />
+                   <ToggleSwitch Content="Enable" Name="enable" IsChecked="True" />
+                   <ToggleSwitch Content="Inset Content" Name="inset" />
+                   <ToggleSwitch Content="ScrollBar Auto Hide" Name="autohide"></ToggleSwitch>
                </StackPanel>
                <DataGrid Grid.Row="1"
                          Margin="8"
@@ -25,8 +26,9 @@
                          CanUserSortColumns="True"
                          HeadersVisibility="All"
                          IsReadOnly="True"
-                         ScrollViewer.AllowAutoHide="{Binding #ScrollViewerHide.IsChecked}"
-                         IsEnabled="{Binding #DisableToggle.IsChecked}"
+                         Classes.InsetContent="{Binding #inset.IsChecked}"
+                         ScrollViewer.AllowAutoHide="{Binding #autohide.IsChecked}"
+                         IsEnabled="{Binding #enable.IsChecked}"
                          ItemsSource="{Binding GridData1}">
                    <DataGrid.Columns>
                        <DataGridTextColumn

--- a/demo/Semi.Avalonia.Demo/Pages/DataGridDemo.axaml
+++ b/demo/Semi.Avalonia.Demo/Pages/DataGridDemo.axaml
@@ -3,7 +3,6 @@
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="using:Semi.Avalonia.Demo.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:vm="clr-namespace:Semi.Avalonia.Demo.ViewModels;assembly=Semi.Avalonia.Demo"
     d:DesignHeight="450"
@@ -17,7 +16,7 @@
                <StackPanel Grid.Row="0" Orientation="Horizontal">
                    <ToggleSwitch Content="Enable" Name="enable" IsChecked="True" />
                    <ToggleSwitch Content="Inset Content" Name="inset" />
-                   <ToggleSwitch Content="ScrollBar Auto Hide" Name="autohide"></ToggleSwitch>
+                   <ToggleSwitch Content="ScrollBar Auto Hide" Name="autohide" />
                </StackPanel>
                <DataGrid Grid.Row="1"
                          Margin="8"

--- a/demo/Semi.Avalonia.Demo/Pages/ScrollViewerDemo.axaml
+++ b/demo/Semi.Avalonia.Demo/Pages/ScrollViewerDemo.axaml
@@ -9,42 +9,15 @@
     mc:Ignorable="d">
     <ScrollViewer>
         <StackPanel HorizontalAlignment="Left" Spacing="20">
+            <ToggleSwitch Name="inset" Content="Inset Content"></ToggleSwitch>
+            <ToggleSwitch Name="autohide" Content="Allow AutoHide"></ToggleSwitch>
             <ScrollViewer
                 Width="200"
                 Height="200"
+                AllowAutoHide="{Binding #autohide.IsChecked}"
+                Classes.InsetContent="{Binding #inset.IsChecked}"
                 Margin="10"
                 HorizontalScrollBarVisibility="Auto">
-                <Grid RowDefinitions="Auto,Auto"
-                      ColumnDefinitions="Auto,Auto"
-                      Width="300" Height="300">
-                    <Rectangle
-                        Grid.Row="0" Grid.Column="0"
-                        Width="150"
-                        Height="150"
-                        Fill="{DynamicResource SemiYellow2}" />
-                    <Rectangle
-                        Grid.Row="0" Grid.Column="1"
-                        Width="150"
-                        Height="150"
-                        Fill="{DynamicResource SemiBlue2}" />
-                    <Rectangle
-                        Grid.Row="1" Grid.Column="0"
-                        Width="150"
-                        Height="150"
-                        Fill="{DynamicResource SemiPink2}" />
-                    <Rectangle
-                        Grid.Row="1" Grid.Column="1"
-                        Width="150"
-                        Height="150"
-                        Fill="{DynamicResource SemiGreen2}" />
-                </Grid>
-            </ScrollViewer>
-            <ScrollViewer
-                Width="200"
-                Height="200"
-                Margin="10"
-                HorizontalScrollBarVisibility="Auto"
-                Theme="{DynamicResource StaticScrollViewer}">
                 <Grid RowDefinitions="Auto,Auto"
                       ColumnDefinitions="Auto,Auto"
                       Width="300" Height="300">

--- a/demo/Semi.Avalonia.Demo/Pages/ScrollViewerDemo.axaml
+++ b/demo/Semi.Avalonia.Demo/Pages/ScrollViewerDemo.axaml
@@ -9,39 +9,22 @@
     mc:Ignorable="d">
     <ScrollViewer>
         <StackPanel HorizontalAlignment="Left" Spacing="20">
-            <ToggleSwitch Name="inset" Content="Inset Content"></ToggleSwitch>
-            <ToggleSwitch Name="autohide" Content="Allow AutoHide"></ToggleSwitch>
+            <ToggleSwitch Name="inset" Content="Inset Content" />
+            <ToggleSwitch Name="autohide" Content="Allow AutoHide" />
             <ScrollViewer
-                Width="200"
-                Height="200"
+                Margin="10"
+                Width="200" Height="200"
                 AllowAutoHide="{Binding #autohide.IsChecked}"
                 Classes.InsetContent="{Binding #inset.IsChecked}"
-                Margin="10"
                 HorizontalScrollBarVisibility="Auto">
-                <Grid RowDefinitions="Auto,Auto"
-                      ColumnDefinitions="Auto,Auto"
-                      Width="300" Height="300">
-                    <Rectangle
-                        Grid.Row="0" Grid.Column="0"
-                        Width="150"
-                        Height="150"
-                        Fill="{DynamicResource SemiYellow2}" />
-                    <Rectangle
-                        Grid.Row="0" Grid.Column="1"
-                        Width="150"
-                        Height="150"
-                        Fill="{DynamicResource SemiBlue2}" />
-                    <Rectangle
-                        Grid.Row="1" Grid.Column="0"
-                        Width="150"
-                        Height="150"
-                        Fill="{DynamicResource SemiPink2}" />
-                    <Rectangle
-                        Grid.Row="1" Grid.Column="1"
-                        Width="150"
-                        Height="150"
-                        Fill="{DynamicResource SemiGreen2}" />
-                </Grid>
+                <UniformGrid
+                    Rows="2" Columns="2"
+                    Width="300" Height="300">
+                    <Rectangle Fill="{DynamicResource SemiYellow2}" />
+                    <Rectangle Fill="{DynamicResource SemiBlue2}" />
+                    <Rectangle Fill="{DynamicResource SemiPink2}" />
+                    <Rectangle Fill="{DynamicResource SemiGreen2}" />
+                </UniformGrid>
             </ScrollViewer>
         </StackPanel>
     </ScrollViewer>

--- a/src/Semi.Avalonia.DataGrid/DataGrid.axaml
+++ b/src/Semi.Avalonia.DataGrid/DataGrid.axaml
@@ -530,6 +530,7 @@
                             Name="PART_VerticalScrollbar"
                             Grid.Row="1"
                             Grid.Column="2"
+                            AllowAutoHide="{Binding Path=(ScrollViewer.AllowAutoHide), RelativeSource={RelativeSource TemplatedParent}}"
                             Orientation="Vertical" />
 
                         <Grid
@@ -540,6 +541,7 @@
                             <ScrollBar
                                 Name="PART_HorizontalScrollbar"
                                 Grid.Column="1"
+                                AllowAutoHide="{Binding Path=(ScrollViewer.AllowAutoHide), RelativeSource={RelativeSource TemplatedParent}}"
                                 Height="{DynamicResource ScrollBarSize}"
                                 Orientation="Horizontal" />
                         </Grid>
@@ -572,7 +574,7 @@
             </Style>
         </Style>
 
-        <Style Selector="^[(ScrollViewer.AllowAutoHide)=False]">
+        <Style Selector="^.InsetContent">
             <Style Selector="^ /template/ DataGridRowsPresenter#PART_RowsPresenter">
                 <Setter Property="Grid.RowSpan" Value="1" />
                 <Setter Property="Grid.ColumnSpan" Value="2" />

--- a/src/Semi.Avalonia/Controls/ScrollViewer.axaml
+++ b/src/Semi.Avalonia/Controls/ScrollViewer.axaml
@@ -229,7 +229,6 @@
                 <Setter Property="Height" Value="2" />
             </Style>
         </Style>
-
     </ControlTheme>
     <ControlTheme x:Key="{x:Type ScrollViewer}" TargetType="ScrollViewer">
         <Setter Property="Background" Value="Transparent" />
@@ -278,9 +277,14 @@
                 <Setter Property="Opacity" Value="1" />
             </Style>
         </Style>
+        <Style Selector="^.InsetContent /template/ ScrollContentPresenter#PART_ContentPresenter">
+            <Setter Property="Grid.RowSpan" Value="1"/>
+            <Setter Property="Grid.ColumnSpan" Value="1"/>
+        </Style>
     </ControlTheme>
 
     <ControlTheme x:Key="StaticScrollViewer" TargetType="ScrollViewer">
+        <!-- This ControlTheme equivalent to default ScrollViewer with InsetContent style class. It exists for easier setting via style.  -->
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Template">
             <ControlTemplate TargetType="ScrollViewer">


### PR DESCRIPTION
Closes #558 
See comments in https://github.com/irihitech/Semi.Avalonia/issues/558#issuecomment-2717938987

We now use `Classes="InsetContent"` to control if scrollbar covers content, and use property `ScrollViewer.AllowAutoHide` to control whether scrollbar shrink automatically. 

||AllowAutoHide=True|AllowAutHide=False|
|:---:|:---:|:---:|
|Classes=InsetContent|滚动条不覆盖内容，可自动收缩，收缩前后内容区域大小有变化|滚动条不覆盖内容，不可自动收缩，滚动条占据固定8px宽度|
|-|滚动条覆盖内容，可自动收缩，收缩前后内容区域大小不变|滚动条覆盖内容，不可自动收缩，固定遮挡8px|