### PR TITLE
enhance DataGrid

### DIFF
--- a/src/Semi.Avalonia.DataGrid/Dark.axaml
+++ b/src/Semi.Avalonia.DataGrid/Dark.axaml
@@ -1,29 +1,21 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <SolidColorBrush x:Key="DataGridLineBrush" Opacity="0.08" Color="White" />
-
+    <StaticResource x:Key="DataGridLineBrush" ResourceKey="SemiColorBorder" />
     <SolidColorBrush x:Key="DataGridCellBackground" Color="Transparent" />
-    <SolidColorBrush x:Key="DataGridCellFocusBorderBrush" Color="#41464C" />
-    <SolidColorBrush x:Key="DataGridCellCurrentBorderBrush" Opacity="0.08" Color="White" />
-    <SolidColorBrush x:Key="DataGridCellErrorBrush" Color="#6C090B" />
-
-
-    <SolidColorBrush x:Key="DataGridColumnHeaderForeground" Opacity="0.6" Color="#F9F9F9" />
+    <StaticResource x:Key="DataGridCellFocusBorderBrush" ResourceKey="SemiColorTertiaryLightActive" />
+    <StaticResource x:Key="DataGridCellCurrentBorderBrush" ResourceKey="SemiColorBorder" />
+    <StaticResource x:Key="DataGridCellErrorBrush" ResourceKey="SemiColorDangerLight" />
+    <StaticResource x:Key="DataGridColumnHeaderForeground" ResourceKey="SemiColorText2" />
     <SolidColorBrush x:Key="DataGridColumnHeaderBackground" Color="Transparent" />
-    <SolidColorBrush x:Key="DataGridColumnHeaderPointeroverBackground" Opacity="0.16" Color="White" />
-    <SolidColorBrush x:Key="DataGridColumnHeaderPressedBackground" Opacity="0.20" Color="White" />
-
+    <StaticResource x:Key="DataGridColumnHeaderPointeroverBackground" ResourceKey="SemiColorFill1" />
+    <StaticResource x:Key="DataGridColumnHeaderPressedBackground" ResourceKey="SemiColorFill2" />
     <SolidColorBrush x:Key="DataGridRowBackground" Color="Transparent" />
-
-    <SolidColorBrush x:Key="DataGridRowErrorBackground" Color="#6C090B" />
+    <StaticResource x:Key="DataGridRowErrorBackground" ResourceKey="SemiColorDangerLight" />
     <SolidColorBrush x:Key="DataGridDetailsPresenterBackground" Color="Transparent" />
-
-    <SolidColorBrush x:Key="DataGridRowPointeroverBackground" Opacity="0.16" Color="White" />
-    <SolidColorBrush x:Key="DataGridRowSelectedBackground" Opacity="0.2" Color="#FF54A9FF" />
-    <SolidColorBrush x:Key="DataGridRowSelectedPointeroverBackground" Opacity="0.3" Color="#FF54A9FF" />
-    <SolidColorBrush x:Key="DataGridRowGroupHeaderExpandIconForeground" Opacity="0.6" Color="#F9F9F9" />
-    <SolidColorBrush x:Key="DataGridRowGroupHeaderBackground" Opacity="0.12" Color="White" />
-
-    <SolidColorBrush x:Key="DataGridRowGroupHeaderCurrentBorderBrush" Opacity="0.08" Color="White" />
-
-    <SolidColorBrush x:Key="DataGridDisabledBackground" Color="#E6E8EA" Opacity="0.04" />
+    <StaticResource x:Key="DataGridRowPointeroverBackground" ResourceKey="SemiColorFill1" />
+    <StaticResource x:Key="DataGridRowSelectedBackground" ResourceKey="SemiColorPrimaryLight" />
+    <StaticResource x:Key="DataGridRowSelectedPointeroverBackground" ResourceKey="SemiColorPrimaryLightPointerover" />
+    <StaticResource x:Key="DataGridRowGroupHeaderExpandIconForeground" ResourceKey="SemiColorText2" />
+    <StaticResource x:Key="DataGridRowGroupHeaderBackground" ResourceKey="SemiColorFill0" />
+    <StaticResource x:Key="DataGridRowGroupHeaderCurrentBorderBrush" ResourceKey="SemiColorBorder" />
+    <StaticResource x:Key="DataGridDisabledBackground" ResourceKey="SemiColorDisabledFill" />
 </ResourceDictionary>

--- a/src/Semi.Avalonia.DataGrid/DataGrid.axaml
+++ b/src/Semi.Avalonia.DataGrid/DataGrid.axaml
@@ -139,8 +139,7 @@
                             <PathIcon
                                 Name="SortIcon"
                                 Grid.Column="1"
-                                Width="8"
-                                Height="8"
+                                Theme="{StaticResource InnerPathIcon}"
                                 Margin="0,0,8,0"
                                 Foreground="{TemplateBinding Foreground}" />
                         </Grid>
@@ -358,8 +357,7 @@
         <Setter Property="Template">
             <ControlTemplate TargetType="ToggleButton">
                 <PathIcon
-                    Width="12"
-                    Height="12"
+                    Theme="{StaticResource InnerPathIcon}"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     Background="Transparent"

--- a/src/Semi.Avalonia.DataGrid/DataGrid.axaml
+++ b/src/Semi.Avalonia.DataGrid/DataGrid.axaml
@@ -128,14 +128,13 @@
                             Margin="4"
                             CornerRadius="3" />
                         <Grid
+                            ColumnDefinitions="*,Auto"
                             Margin="{TemplateBinding Padding}"
                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <ContentPresenter Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" />
+                            <ContentPresenter
+                                Content="{TemplateBinding Content}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}" />
                             <PathIcon
                                 Name="SortIcon"
                                 Grid.Column="1"
@@ -398,20 +397,18 @@
                         Grid.Column="3"
                         Margin="12,0,0,0"
                         VerticalAlignment="Center"
-                        Orientation="Horizontal">
+                        Orientation="Horizontal"
+                        Spacing="4">
                         <TextBlock
                             Name="PART_PropertyNameElement"
-                            Margin="4,0,0,0"
                             Foreground="{TemplateBinding Foreground}"
                             IsVisible="{TemplateBinding IsPropertyNameVisible}" />
                         <ContentControl
                             Name="PART_GroupKeyContentControl"
-                            Margin="4,0,0,0"
                             Foreground="{TemplateBinding Foreground}"
                             Content="{Binding Key}" />
                         <TextBlock
                             Name="PART_ItemCountElement"
-                            Margin="4,0,0,0"
                             Foreground="{TemplateBinding Foreground}"
                             IsVisible="{TemplateBinding IsItemCountVisible}" />
                     </StackPanel>

--- a/src/Semi.Avalonia.DataGrid/DataGrid.axaml
+++ b/src/Semi.Avalonia.DataGrid/DataGrid.axaml
@@ -126,7 +126,7 @@
                             Name="HeaderBackground"
                             Grid.ColumnSpan="2"
                             Margin="4"
-                            CornerRadius="3" />
+                            CornerRadius="{DynamicResource DataGridColumnHeaderCornerRadius}" />
                         <Grid
                             ColumnDefinitions="*,Auto"
                             Margin="{TemplateBinding Padding}"
@@ -291,7 +291,7 @@
                             Grid.ColumnSpan="2"
                             Margin="{DynamicResource DataGridRowMargin}"
                             Background="{DynamicResource DataGridRowBackground}"
-                            CornerRadius="3" />
+                            CornerRadius="{DynamicResource DataGridRowCornerRadius}" />
                         <Rectangle
                             Name="InvalidVisualElement"
                             Grid.ColumnSpan="2"
@@ -372,7 +372,7 @@
     <ControlTheme x:Key="{x:Type DataGridRowGroupHeader}" TargetType="DataGridRowGroupHeader">
         <Setter Property="Focusable" Value="False" />
         <Setter Property="Background" Value="{DynamicResource DataGridRowGroupHeaderBackground}" />
-        <Setter Property="MinHeight" Value="32" />
+        <Setter Property="MinHeight" Value="{DynamicResource DataGridRowGroupHeaderMinHeight}" />
         <Setter Property="Template">
             <ControlTemplate x:DataType="collections:DataGridCollectionViewGroup" TargetType="DataGridRowGroupHeader">
                 <DataGridFrozenGrid
@@ -549,7 +549,7 @@
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
                             Background="{DynamicResource DataGridDisabledBackground}"
-                            CornerRadius="2"
+                            CornerRadius="{DynamicResource DataGridDisabledCornerRadius}"
                             IsHitTestVisible="False"
                             IsVisible="{Binding !$parent[DataGrid].IsEnabled}" />
                     </Grid>

--- a/src/Semi.Avalonia.DataGrid/Light.axaml
+++ b/src/Semi.Avalonia.DataGrid/Light.axaml
@@ -1,29 +1,21 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <SolidColorBrush x:Key="DataGridLineBrush" Opacity="0.08" Color="#1C1F23" />
-
+    <StaticResource x:Key="DataGridLineBrush" ResourceKey="SemiColorBorder" />
     <SolidColorBrush x:Key="DataGridCellBackground" Color="Transparent" />
-    <SolidColorBrush x:Key="DataGridCellFocusBorderBrush" Color="#C6CACD" />
-    <SolidColorBrush x:Key="DataGridCellCurrentBorderBrush" Opacity="0.08" Color="#1C1F23" />
-    <SolidColorBrush x:Key="DataGridCellErrorBrush" Color="#FEF2ED" />
-
-
-    <SolidColorBrush x:Key="DataGridColumnHeaderForeground" Opacity="0.62" Color="#1C1F23" />
+    <StaticResource x:Key="DataGridCellFocusBorderBrush" ResourceKey="SemiColorTertiaryLightActive" />
+    <StaticResource x:Key="DataGridCellCurrentBorderBrush" ResourceKey="SemiColorBorder" />
+    <StaticResource x:Key="DataGridCellErrorBrush" ResourceKey="SemiColorDangerLight" />
+    <StaticResource x:Key="DataGridColumnHeaderForeground" ResourceKey="SemiColorText2" />
     <SolidColorBrush x:Key="DataGridColumnHeaderBackground" Color="Transparent" />
-    <SolidColorBrush x:Key="DataGridColumnHeaderPointeroverBackground" Opacity="0.09" Color="#2E3238" />
-    <SolidColorBrush x:Key="DataGridColumnHeaderPressedBackground" Opacity="0.13" Color="#2E3238" />
-
+    <StaticResource x:Key="DataGridColumnHeaderPointeroverBackground" ResourceKey="SemiColorFill1" />
+    <StaticResource x:Key="DataGridColumnHeaderPressedBackground" ResourceKey="SemiColorFill2" />
     <SolidColorBrush x:Key="DataGridRowBackground" Color="Transparent" />
-
-    <SolidColorBrush x:Key="DataGridRowErrorBackground" Color="#FEF2ED" />
+    <StaticResource x:Key="DataGridRowErrorBackground" ResourceKey="SemiColorDangerLight" />
     <SolidColorBrush x:Key="DataGridDetailsPresenterBackground" Color="Transparent" />
-
-    <SolidColorBrush x:Key="DataGridRowPointeroverBackground" Opacity="0.09" Color="#2E3238" />
-    <SolidColorBrush x:Key="DataGridRowSelectedBackground" Color="#EAF5FF" />
-    <SolidColorBrush x:Key="DataGridRowSelectedPointeroverBackground" Color="#CBE7FE" />
-    <SolidColorBrush x:Key="DataGridRowGroupHeaderExpandIconForeground" Opacity="0.62" Color="#1C1F23" />
-    <SolidColorBrush x:Key="DataGridRowGroupHeaderBackground" Opacity="0.05" Color="#2E3238" />
-
-    <SolidColorBrush x:Key="DataGridRowGroupHeaderCurrentBorderBrush" Opacity="0.08" Color="#1C1F23" />
-
-    <SolidColorBrush x:Key="DataGridDisabledBackground" Color="#2E3238" Opacity="0.02" />
+    <StaticResource x:Key="DataGridRowPointeroverBackground" ResourceKey="SemiColorFill1" />
+    <StaticResource x:Key="DataGridRowSelectedBackground" ResourceKey="SemiColorPrimaryLight" />
+    <StaticResource x:Key="DataGridRowSelectedPointeroverBackground" ResourceKey="SemiColorPrimaryLightPointerover" />
+    <StaticResource x:Key="DataGridRowGroupHeaderExpandIconForeground" ResourceKey="SemiColorText2" />
+    <StaticResource x:Key="DataGridRowGroupHeaderBackground" ResourceKey="SemiColorFill0" />
+    <StaticResource x:Key="DataGridRowGroupHeaderCurrentBorderBrush" ResourceKey="SemiColorBorder" />
+    <StaticResource x:Key="DataGridDisabledBackground" ResourceKey="SemiColorDisabledFill" />
 </ResourceDictionary>

--- a/src/Semi.Avalonia.DataGrid/Shared.axaml
+++ b/src/Semi.Avalonia.DataGrid/Shared.axaml
@@ -1,20 +1,22 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Thickness x:Key="DataGridCellTextBlockDefaultMargin">12 0</Thickness>
-
-    <x:Double x:Key="DataGridCellMinHeight">32</x:Double>
-    <Thickness x:Key="DataGridCellVisualBorderThickness">1</Thickness>
-    <x:Double x:Key="DataGridCellVisualStrokeThickness">1</x:Double>
+    <StaticResource x:Key="DataGridCellMinHeight" ResourceKey="SemiHeightControlDefault" />
+    <StaticResource x:Key="DataGridCellVisualBorderThickness" ResourceKey="SemiBorderThicknessControl" />
+    <StaticResource x:Key="DataGridCellVisualStrokeThickness" ResourceKey="SemiBorderSpacingControl" />
 
     <Thickness x:Key="DataGridColumnHeaderPadding">12 0 0 0</Thickness>
-    <x:Double x:Key="DataGridColumnHeaderMinHeight">32</x:Double>
-
+    <StaticResource x:Key="DataGridColumnHeaderMinHeight" ResourceKey="SemiHeightControlDefault" />
+    <StaticResource x:Key="DataGridColumnHeaderCornerRadius" ResourceKey="SemiBorderRadiusSmall" />
     <StaticResource x:Key="DataGridColumnHeaderAscendingGlyph" ResourceKey="SemiIconSmallTriangleTop" />
     <StaticResource x:Key="DataGridColumnHeaderDescendingGlyph" ResourceKey="SemiIconSmallTriangleDown" />
 
     <Thickness x:Key="DataGridRowHeaderMargin">8 0</Thickness>
-    <Thickness x:Key="DataGridRowMargin">2</Thickness>
+    <StaticResource x:Key="DataGridRowCornerRadius" ResourceKey="SemiBorderRadiusSmall" />
+    <StaticResource x:Key="DataGridRowMargin" ResourceKey="SemiThicknessSuperTight" />
 
+    <StaticResource x:Key="DataGridRowGroupHeaderMinHeight" ResourceKey="SemiHeightControlDefault" />
     <StaticResource x:Key="DataGridRowGroupHeaderExpandIconGlyph" ResourceKey="SemiIconChevronRight" />
+    <StaticResource x:Key="DataGridRowGroupHeaderVisualStrokeThickness" ResourceKey="SemiBorderSpacingControl" />
 
-    <x:Double x:Key="DataGridRowGroupHeaderVisualStrokeThickness">1</x:Double>
+    <StaticResource x:Key="DataGridDisabledCornerRadius" ResourceKey="SemiBorderRadiusSmall" />
 </ResourceDictionary>

--- a/src/Semi.Avalonia.DataGrid/Shared.axaml
+++ b/src/Semi.Avalonia.DataGrid/Shared.axaml
@@ -8,16 +8,13 @@
     <Thickness x:Key="DataGridColumnHeaderPadding">12 0 0 0</Thickness>
     <x:Double x:Key="DataGridColumnHeaderMinHeight">32</x:Double>
 
-    <StreamGeometry x:Key="DataGridColumnHeaderAscendingGlyph">m6.45 8.34 4.8-5.48a1 1 0 0 1 1.5 0l4.8 5.48A1 1 0 0 1 16.8 10H7.2a1 1 0 0 1-.75-1.66Z</StreamGeometry>
-    <StreamGeometry x:Key="DataGridColumnHeaderDescendingGlyph">m17.55 15.66-4.8 5.48a1 1 0 0 1-1.5 0l-4.8-5.48A1 1 0 0 1 7.2 14h9.6a1 1 0 0 1 .75 1.66Z</StreamGeometry>
-    <!-- <StaticResource x:Key="DataGridColumnHeaderAscendingGlyph" ResourceKey="SemiIconCaretUp" /> -->
-    <!-- <StaticResource x:Key="DataGridColumnHeaderDescendingGlyph" ResourceKey="SemiIconCaretDown" /> -->
+    <StaticResource x:Key="DataGridColumnHeaderAscendingGlyph" ResourceKey="SemiIconSmallTriangleTop" />
+    <StaticResource x:Key="DataGridColumnHeaderDescendingGlyph" ResourceKey="SemiIconSmallTriangleDown" />
 
     <Thickness x:Key="DataGridRowHeaderMargin">8 0</Thickness>
     <Thickness x:Key="DataGridRowMargin">2</Thickness>
 
-    <StreamGeometry x:Key="DataGridRowGroupHeaderExpandIconGlyph">M7.44 19.8a1.5 1.5 0 0 1 0-2.13l5.66-5.65-5.66-5.66a1.5 1.5 0 1 1 2.12-2.12l6.72 6.72a1.5 1.5 0 0 1 0 2.12L9.56 19.8a1.5 1.5 0 0 1-2.12 0Z</StreamGeometry>
-    <!-- <StaticResource x:Key="DataGridRowGroupHeaderExpandIconGlyph" ResourceKey="SemiIconChevronRight" /> -->
+    <StaticResource x:Key="DataGridRowGroupHeaderExpandIconGlyph" ResourceKey="SemiIconChevronRight" />
 
     <x:Double x:Key="DataGridRowGroupHeaderVisualStrokeThickness">1</x:Double>
 </ResourceDictionary>


### PR DESCRIPTION
This pull request includes updates to the `Semi.Avalonia.DataGrid` project to replace hardcoded values with `StaticResource` references for better maintainability and consistency. The changes affect multiple `.axaml` files, including `Dark.axaml`, `Light.axaml`, `DataGrid.axaml`, and `Shared.axaml`.

### Theme and Resource Updates:

* [`src/Semi.Avalonia.DataGrid/Dark.axaml`](diffhunk://#diff-22b341685d8038c291982793ca967fdb434dc49a99cbdb1aecdd1fea1d66d109L2-R20): Replaced `SolidColorBrush` definitions with `StaticResource` references for various `DataGrid` elements to use predefined theme colors.
* [`src/Semi.Avalonia.DataGrid/Light.axaml`](diffhunk://#diff-22b341685d8038c291982793ca967fdb434dc49a99cbdb1aecdd1fea1d66d109L2-R20): Similar updates to `Dark.axaml`, replacing `SolidColorBrush` definitions with `StaticResource` references for consistency with the light theme.

### DataGrid Template and Style Enhancements:

* [`src/Semi.Avalonia.DataGrid/DataGrid.axaml`](diffhunk://#diff-49631546f675fb616f81e51c36282d75a86ea55bb6a83c9a255110c2894826e5L129-R141): Updated `CornerRadius` and other properties to use `DynamicResource` for better flexibility and theming support. [[1]](diffhunk://#diff-49631546f675fb616f81e51c36282d75a86ea55bb6a83c9a255110c2894826e5L129-R141) [[2]](diffhunk://#diff-49631546f675fb616f81e51c36282d75a86ea55bb6a83c9a255110c2894826e5L296-R294) [[3]](diffhunk://#diff-49631546f675fb616f81e51c36282d75a86ea55bb6a83c9a255110c2894826e5L557-R552)
* [`src/Semi.Avalonia.DataGrid/DataGrid.axaml`](diffhunk://#diff-49631546f675fb616f81e51c36282d75a86ea55bb6a83c9a255110c2894826e5L361-R359): Added `Spacing` attribute to `StackPanel` and replaced hardcoded icon themes with `StaticResource` references. [[1]](diffhunk://#diff-49631546f675fb616f81e51c36282d75a86ea55bb6a83c9a255110c2894826e5L361-R359) [[2]](diffhunk://#diff-49631546f675fb616f81e51c36282d75a86ea55bb6a83c9a255110c2894826e5L403-L416)

### Shared Resource Definitions:

* [`src/Semi.Avalonia.DataGrid/Shared.axaml`](diffhunk://#diff-b987d6068270aaafd48265521849bf7488e5a1e5454834c96a199244d6dbdc86L3-R21): Replaced hardcoded values with `StaticResource` references for shared properties like `MinHeight`, `CornerRadius`, and icons. This change ensures consistency across different parts of the DataGrid.

These updates enhance the maintainability and theming capabilities of the `Semi.Avalonia.DataGrid` components by centralizing style definitions and making it easier to update and manage UI elements consistently.