### PR TITLE
add ThicknessBridge & CornerRadiusBridge MarkupExtension

### DIFF
--- a/demo/Semi.Avalonia.Demo/Pages/MarkupExtensionDemo.axaml
+++ b/demo/Semi.Avalonia.Demo/Pages/MarkupExtensionDemo.axaml
@@ -1,0 +1,88 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:semi="https://irihi.tech/semi"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Semi.Avalonia.Demo.Pages.MarkupExtensionDemo">
+    <UserControl.Styles>
+        <Style Selector="Border.base">
+            <Setter Property="VerticalAlignment" Value="Top" />
+            <Setter Property="Background" Value="{DynamicResource SemiColorFill2}" />
+        </Style>
+    </UserControl.Styles>
+    <StackPanel HorizontalAlignment="Left" Margin="20" Spacing="20">
+        <TextBlock Text="Original" />
+        <StackPanel Orientation="Horizontal" Spacing="20">
+            <Border Classes="base"
+                    Padding="20"
+                    CornerRadius="12">
+                <TextBlock Text="〇" />
+            </Border>
+            <Border Classes="base"
+                    Padding="0 0 20 0"
+                    CornerRadius="0 12 0 0">
+                <TextBlock Text="〇" />
+            </Border>
+            <Border Classes="base"
+                    Padding="20 40"
+                    CornerRadius="12 3 12 3">
+                <TextBlock Text="〇" />
+            </Border>
+            <Border Classes="base"
+                    Padding="12 20 32 40"
+                    CornerRadius="3 6 12 9999">
+                <TextBlock Text="〇" />
+            </Border>
+        </StackPanel>
+        <TextBlock Text="ThicknessBridge, CornerRadiusBridge" />
+        <StackPanel Orientation="Horizontal" Spacing="20">
+            <Border
+                Classes="base"
+                Padding="{StaticResource SemiThicknessBaseLoose}"
+                CornerRadius="{StaticResource SemiBorderRadiusLarge}">
+                <TextBlock Text="〇" />
+            </Border>
+            <Border
+                Classes="base"
+                Padding="{semi:ThicknessBridge Right={StaticResource SemiSpacingBaseLoose}}"
+                CornerRadius="{semi:CornerRadiusBridge TopRight={StaticResource SemiBorderRadiusSpacingLarge}}">
+                <TextBlock Text="〇" />
+            </Border>
+            <Border
+                Classes="base"
+                Padding="{semi:ThicknessBridge 
+                    Left={StaticResource SemiSpacingBaseLoose},
+                    Top={StaticResource SemiSpacingSuperLoose},
+                    Right={StaticResource SemiSpacingBaseLoose},
+                    Bottom={StaticResource SemiSpacingSuperLoose}
+                }"
+                CornerRadius="{semi:CornerRadiusBridge
+                    TopLeft={StaticResource SemiBorderRadiusSpacingLarge},
+                    TopRight={StaticResource SemiBorderRadiusSpacingSmall},
+                    BottomRight={StaticResource SemiBorderRadiusSpacingLarge},
+                    BottomLeft={StaticResource SemiBorderRadiusSpacingSmall}
+                }">
+                <TextBlock Text="〇" />
+            </Border>
+            <Border
+                Classes="base">
+                <Border.Padding>
+                    <semi:ThicknessBridge
+                        Left="{StaticResource SemiSpacingBaseTight}"
+                        Top="{StaticResource SemiSpacingBaseLoose}"
+                        Right="{StaticResource SemiSpacingExtraLoose}"
+                        Bottom="{StaticResource SemiSpacingSuperLoose}" />
+                </Border.Padding>
+                <Border.CornerRadius>
+                    <semi:CornerRadiusBridge
+                        TopLeft="{StaticResource SemiBorderRadiusSpacingSmall}"
+                        TopRight="{StaticResource SemiBorderRadiusSpacingMedium}"
+                        BottomRight="{StaticResource SemiBorderRadiusSpacingLarge}"
+                        BottomLeft="{StaticResource SemiBorderRadiusSpacingFull}" />
+                </Border.CornerRadius>
+                <TextBlock Text="〇" />
+            </Border>
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/demo/Semi.Avalonia.Demo/Pages/MarkupExtensionDemo.axaml.cs
+++ b/demo/Semi.Avalonia.Demo/Pages/MarkupExtensionDemo.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Semi.Avalonia.Demo.Pages;
+
+public partial class MarkupExtensionDemo : UserControl
+{
+    public MarkupExtensionDemo()
+    {
+        InitializeComponent();
+    }
+}

--- a/demo/Semi.Avalonia.Demo/Views/MainView.axaml
+++ b/demo/Semi.Avalonia.Demo/Views/MainView.axaml
@@ -97,6 +97,9 @@
             <TabItem Header="Icon">
                 <pages:IconDemo />
             </TabItem>
+            <TabItem Header="MarkupExtensions">
+                <pages:MarkupExtensionDemo />
+            </TabItem>
             <TabItem Header="AutoCompleteBox">
                 <pages:AutoCompleteBoxDemo />
             </TabItem>

--- a/src/Semi.Avalonia/AssemblyInfo.cs
+++ b/src/Semi.Avalonia/AssemblyInfo.cs
@@ -2,3 +2,4 @@
 
 [assembly:XmlnsPrefix("https://irihi.tech/semi", "semi")]
 [assembly:XmlnsDefinition("https://irihi.tech/semi", "Semi.Avalonia")]
+[assembly:XmlnsDefinition("https://irihi.tech/semi", "Semi.Avalonia.Markup.Xaml")]

--- a/src/Semi.Avalonia/MarkupExtensions/CornerRadiusBridgeExtension.cs
+++ b/src/Semi.Avalonia/MarkupExtensions/CornerRadiusBridgeExtension.cs
@@ -1,0 +1,40 @@
+using System;
+using Avalonia;
+
+namespace Semi.Avalonia.Markup.Xaml;
+
+public class CornerRadiusBridgeExtension
+{
+    public double TopLeft { get; set; }
+    public double TopRight { get; set; }
+    public double BottomRight { get; set; }
+    public double BottomLeft { get; set; }
+
+    public CornerRadiusBridgeExtension()
+    {
+    }
+
+    public CornerRadiusBridgeExtension(double uniformRadius)
+    {
+        TopLeft = TopRight = BottomLeft = BottomRight = uniformRadius;
+    }
+
+    public CornerRadiusBridgeExtension(double top, double bottom)
+    {
+        TopLeft = TopRight = top;
+        BottomLeft = BottomRight = bottom;
+    }
+
+    public CornerRadiusBridgeExtension(double topLeft, double topRight, double bottomRight, double bottomLeft)
+    {
+        TopLeft = topLeft;
+        TopRight = topRight;
+        BottomRight = bottomRight;
+        BottomLeft = bottomLeft;
+    }
+
+    public CornerRadius ProvideValue(IServiceProvider serviceProvider)
+    {
+        return new CornerRadius(TopLeft, TopRight, BottomRight, BottomLeft);
+    }
+}

--- a/src/Semi.Avalonia/MarkupExtensions/ThicknessBridgeExtension.cs
+++ b/src/Semi.Avalonia/MarkupExtensions/ThicknessBridgeExtension.cs
@@ -1,0 +1,40 @@
+using System;
+using Avalonia;
+
+namespace Semi.Avalonia.Markup.Xaml;
+
+public class ThicknessBridgeExtension
+{
+    public double Left { get; set; }
+    public double Top { get; set; }
+    public double Right { get; set; }
+    public double Bottom { get; set; }
+
+    public ThicknessBridgeExtension()
+    {
+    }
+
+    public ThicknessBridgeExtension(double uniformLength)
+    {
+        Left = Right = Top = Bottom = uniformLength;
+    }
+
+    public ThicknessBridgeExtension(double horizontal, double vertical)
+    {
+        Left = Right = horizontal;
+        Top = Bottom = vertical;
+    }
+
+    public ThicknessBridgeExtension(double left, double top, double right, double bottom)
+    {
+        Left = left;
+        Top = top;
+        Right = right;
+        Bottom = bottom;
+    }
+
+    public Thickness ProvideValue(IServiceProvider serviceProvider)
+    {
+        return new Thickness(Left, Top, Right, Bottom);
+    }
+}

--- a/src/Semi.Avalonia/Tokens/Variables.axaml
+++ b/src/Semi.Avalonia/Tokens/Variables.axaml
@@ -19,6 +19,11 @@
     <Thickness x:Key="SemiBorderThickness">0</Thickness> <!-- 描边宽度 - 零 -->
     <Thickness x:Key="SemiBorderThicknessControl">1</Thickness> <!-- 描边宽度 - 默认状态 -->
     <Thickness x:Key="SemiBorderThicknessControlFocus">1</Thickness> <!-- 描边宽度 - focus 状态 -->
+    <x:Double x:Key="SemiBorderRadiusSpacingExtraSmall">3</x:Double> <!-- 圆角半径 - 超小 -->
+    <x:Double x:Key="SemiBorderRadiusSpacingSmall">3</x:Double> <!-- 圆角半径 - 小 -->
+    <x:Double x:Key="SemiBorderRadiusSpacingMedium">6</x:Double> <!-- 圆角半径 - 中 -->
+    <x:Double x:Key="SemiBorderRadiusSpacingLarge">12</x:Double> <!-- 圆角半径 - 大 -->
+    <x:Double x:Key="SemiBorderRadiusSpacingFull">9999</x:Double> <!-- 圆角半径 - 全圆 -->
     <CornerRadius x:Key="SemiBorderRadiusExtraSmall">3</CornerRadius> <!-- 圆角 - 超小 -->
     <CornerRadius x:Key="SemiBorderRadiusSmall">3</CornerRadius> <!-- 圆角 - 小 -->
     <CornerRadius x:Key="SemiBorderRadiusMedium">6</CornerRadius> <!-- 圆角 - 中 -->


### PR DESCRIPTION
This pull request introduces a new `MarkupExtensionDemo` page to demonstrate the usage of custom markup extensions for `Thickness` and `CornerRadius` in Avalonia. It includes updates to the demo application and adds new markup extensions to the `Semi.Avalonia` library.

### Demo Application Updates:
* Added a new `MarkupExtensionDemo` page with various `Border` elements showcasing different `Thickness` and `CornerRadius` configurations. (`demo/Semi.Avalonia.Demo/Pages/MarkupExtensionDemo.axaml`, `demo/Semi.Avalonia.Demo/Pages/MarkupExtensionDemo.axaml.cs`) [[1]](diffhunk://#diff-7c1010310bf088cdbffd0e6f5423cb5a8dd8b0df2e278c0c2d99c542333d4a0dR1-R88) [[2]](diffhunk://#diff-3714e3a505869ff77580effdecaca88fc851eb7316dfaf2789f754bd348d3d9aR1-R11)
* Updated `MainView` to include a tab for the new `MarkupExtensionDemo` page. (`demo/Semi.Avalonia.Demo/Views/MainView.axaml`)

### Library Enhancements:
* Added `CornerRadiusBridgeExtension` to allow setting `CornerRadius` values via markup extensions. (`src/Semi.Avalonia/MarkupExtensions/CornerRadiusBridgeExtension.cs`)
* Added `ThicknessBridgeExtension` to allow setting `Thickness` values via markup extensions. (`src/Semi.Avalonia/MarkupExtensions/ThicknessBridgeExtension.cs`)
* Updated `AssemblyInfo.cs` to include the new namespace for markup extensions. (`src/Semi.Avalonia/AssemblyInfo.cs`)

### Resource Definitions:
* Added new resource definitions for various `CornerRadius` values in `Variables.axaml`. (`src/Semi.Avalonia/Tokens/Variables.axaml`)