### PR TITLE
Redesign TabStrip

### DIFF
--- a/demo/Semi.Avalonia.Demo/Pages/TabStripDemo.axaml
+++ b/demo/Semi.Avalonia.Demo/Pages/TabStripDemo.axaml
@@ -1,0 +1,93 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:Semi.Avalonia.Demo.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Semi.Avalonia.Demo.Pages.TabStripDemo"
+             x:DataType="vm:TabStripDemoViewModel">
+    <Design.DataContext>
+        <vm:TabStripDemoViewModel />
+    </Design.DataContext>
+    <ScrollViewer>
+        <StackPanel>
+            <TabControl Theme="{StaticResource LineTabControl}">
+                <TabItem Header="Default">
+                    <StackPanel>
+                        <Border Theme="{StaticResource CardBorder}">
+                            <TabStrip>
+                                <TabStripItem Content="Tab 1" />
+                                <TabStripItem Content="Tab 2" />
+                                <TabStripItem Content="Tab 3" />
+                                <TabStripItem Content="中文中文" />
+                                <TabStripItem Content="Tab 4" IsEnabled="False" />
+                            </TabStrip>
+                        </Border>
+                        <Border Theme="{StaticResource CardBorder}">
+                            <TabStrip
+                                ItemsSource="{Binding Items}" />
+                        </Border>
+                    </StackPanel>
+                </TabItem>
+                <TabItem Header="Line">
+                    <StackPanel>
+                        <Border Theme="{StaticResource CardBorder}">
+                            <TabStrip Theme="{StaticResource LineTabStrip}">
+                                <TabStripItem Content="Tab 1" />
+                                <TabStripItem Content="Tab 2" />
+                                <TabStripItem Content="Tab 3" />
+                                <TabStripItem Content="中文中文" />
+                                <TabStripItem Content="Tab 4" IsEnabled="False" />
+                            </TabStrip>
+                        </Border>
+                        <Border Theme="{StaticResource CardBorder}">
+                            <TabStrip
+                                ItemsSource="{Binding Items}"
+                                Theme="{StaticResource LineTabStrip}" />
+                        </Border>
+                    </StackPanel>
+                </TabItem>
+                <TabItem Header="Card">
+                    <StackPanel>
+                        <Border
+                            Background="Transparent"
+                            Theme="{StaticResource CardBorder}">
+                            <TabStrip Theme="{StaticResource CardTabStrip}">
+                                <TabStripItem Content="Tab 1" />
+                                <TabStripItem Content="Tab 2" />
+                                <TabStripItem Content="Tab 3" />
+                                <TabStripItem Content="中文中文" />
+                                <TabStripItem Content="Tab 4" IsEnabled="False" />
+                            </TabStrip>
+                        </Border>
+                        <Border
+                            Background="Transparent"
+                            Theme="{StaticResource CardBorder}">
+                            <TabStrip
+                                ItemsSource="{Binding Items}"
+                                Theme="{StaticResource CardTabStrip}" />
+                        </Border>
+                    </StackPanel>
+                </TabItem>
+                <TabItem Header="Button">
+                    <StackPanel>
+                        <Border Theme="{StaticResource CardBorder}">
+                            <TabStrip Theme="{StaticResource ButtonTabStrip}">
+                                <TabStripItem Content="Tab 1" />
+                                <TabStripItem Content="Tab 2" />
+                                <TabStripItem Content="Tab 3" />
+                                <TabStripItem Content="中文中文" />
+                                <TabStripItem Content="Tab 4" IsEnabled="False" />
+                            </TabStrip>
+                        </Border>
+                        <Border Theme="{StaticResource CardBorder}">
+                            <TabStrip
+                                ItemsSource="{Binding Items}"
+                                Theme="{StaticResource ButtonTabStrip}" />
+                        </Border>
+                    </StackPanel>
+                </TabItem>
+            </TabControl>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/demo/Semi.Avalonia.Demo/Pages/TabStripDemo.axaml.cs
+++ b/demo/Semi.Avalonia.Demo/Pages/TabStripDemo.axaml.cs
@@ -1,0 +1,13 @@
+﻿using Avalonia.Controls;
+using Semi.Avalonia.Demo.ViewModels;
+
+namespace Semi.Avalonia.Demo.Pages;
+
+public partial class TabStripDemo : UserControl
+{
+    public TabStripDemo()
+    {
+        InitializeComponent();
+        this.DataContext = new TabStripDemoViewModel();
+    }
+}

--- a/demo/Semi.Avalonia.Demo/ViewModels/TabStripDemoViewModel.cs
+++ b/demo/Semi.Avalonia.Demo/ViewModels/TabStripDemoViewModel.cs
@@ -1,0 +1,10 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Semi.Avalonia.Demo.ViewModels;
+
+public class TabStripDemoViewModel : ObservableObject
+{
+    public ObservableCollection<string> Items => new(Enumerable.Range(1, 10).Select(a => "Tab " + a));
+}

--- a/demo/Semi.Avalonia.Demo/Views/MainView.axaml
+++ b/demo/Semi.Avalonia.Demo/Views/MainView.axaml
@@ -219,6 +219,9 @@
             <TabItem Header="TabControl">
                 <pages:TabControlDemo />
             </TabItem>
+            <TabItem Header="TabStrip">
+                <pages:TabStripDemo />
+            </TabItem>
             <TabItem Header="TreeView">
                 <pages:TreeViewDemo />
             </TabItem>

--- a/src/Semi.Avalonia/Controls/TabStrip.axaml
+++ b/src/Semi.Avalonia/Controls/TabStrip.axaml
@@ -13,7 +13,7 @@
     </Design.PreviewWith>
 
     <ControlTheme x:Key="{x:Type TabStrip}" TargetType="TabStrip">
-        <Setter Property="VerticalAlignment" Value="Top"/>
+        <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="Template">
             <ControlTemplate TargetType="TabStrip">
                 <Border
@@ -52,7 +52,7 @@
         BasedOn="{StaticResource {x:Type TabStrip}}"
         TargetType="TabStrip">
         <Setter Property="ItemContainerTheme" Value="{StaticResource CardTabStripItem}" />
-        <Setter Property="VerticalAlignment" Value="Top"/>
+        <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="Template">
             <ControlTemplate TargetType="TabStrip">
                 <Border

--- a/src/Semi.Avalonia/Controls/TabStrip.axaml
+++ b/src/Semi.Avalonia/Controls/TabStrip.axaml
@@ -13,6 +13,7 @@
     </Design.PreviewWith>
 
     <ControlTheme x:Key="{x:Type TabStrip}" TargetType="TabStrip">
+        <Setter Property="VerticalAlignment" Value="Top"/>
         <Setter Property="Template">
             <ControlTemplate TargetType="TabStrip">
                 <Border
@@ -51,6 +52,7 @@
         BasedOn="{StaticResource {x:Type TabStrip}}"
         TargetType="TabStrip">
         <Setter Property="ItemContainerTheme" Value="{StaticResource CardTabStripItem}" />
+        <Setter Property="VerticalAlignment" Value="Top"/>
         <Setter Property="Template">
             <ControlTemplate TargetType="TabStrip">
                 <Border

--- a/src/Semi.Avalonia/Controls/TabStrip.axaml
+++ b/src/Semi.Avalonia/Controls/TabStrip.axaml
@@ -2,108 +2,213 @@
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     x:CompileBindings="True">
+    <Design.PreviewWith>
+        <StackPanel Width="400" Height="400" Margin="20">
+            <TabStrip Theme="{DynamicResource LineTabStrip}">
+                <TabStripItem Content="文档" />
+                <TabStripItem Content="快速起步" IsEnabled="False" />
+                <TabStripItem Content="帮助" IsSelected="True" />
+            </TabStrip>
+        </StackPanel>
+    </Design.PreviewWith>
+
     <ControlTheme x:Key="{x:Type TabStrip}" TargetType="TabStrip">
         <Setter Property="Template">
-            <ControlTemplate>
+            <ControlTemplate TargetType="TabStrip">
                 <Border
-                    Padding="{TemplateBinding Padding}"
+                    HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                    VerticalAlignment="{TemplateBinding VerticalAlignment}"
                     Background="{TemplateBinding Background}"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}"
                     CornerRadius="{TemplateBinding CornerRadius}">
                     <Panel>
-                        <ItemsPresenter Name="PART_ItemsPresenter" ItemsPanel="{TemplateBinding ItemsPanel}" />
-                        <Border
-                            Name="PART_BorderSeparator"
-                            Height="1"
-                            HorizontalAlignment="Stretch"
-                            VerticalAlignment="Bottom"
-                            Background="{DynamicResource TabItemLinePipePressedBorderBrush}" />
+                        <ItemsPresenter
+                            Name="PART_ItemsPresenter"
+                            ItemsPanel="{TemplateBinding ItemsPanel}" />
+                        <Border Name="PART_BorderSeparator" />
                     </Panel>
                 </Border>
             </ControlTemplate>
         </Setter>
-        <Setter Property="ItemsPanel">
-            <ItemsPanelTemplate>
-                <WrapPanel />
-            </ItemsPanelTemplate>
+
+        <Style Selector="^ /template/ Border#PART_BorderSeparator">
+            <Setter Property="Background" Value="{DynamicResource TabControlSeparatorBorderBrush}" />
+            <Setter Property="Height" Value="1" />
+            <Setter Property="VerticalAlignment" Value="Bottom" />
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme
+        x:Key="LineTabStrip"
+        BasedOn="{StaticResource {x:Type TabStrip}}"
+        TargetType="TabStrip">
+        <Setter Property="ItemContainerTheme" Value="{StaticResource LineTabStripItem}" />
+    </ControlTheme>
+
+    <ControlTheme
+        x:Key="CardTabStrip"
+        BasedOn="{StaticResource {x:Type TabStrip}}"
+        TargetType="TabStrip">
+        <Setter Property="ItemContainerTheme" Value="{StaticResource CardTabStripItem}" />
+        <Setter Property="Template">
+            <ControlTemplate TargetType="TabStrip">
+                <Border
+                    HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                    VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                    Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}"
+                    CornerRadius="{TemplateBinding CornerRadius}">
+                    <Panel>
+                        <Border Name="PART_BorderSeparator" />
+                        <ItemsPresenter
+                            Name="PART_ItemsPresenter"
+                            ItemsPanel="{TemplateBinding ItemsPanel}" />
+                    </Panel>
+                </Border>
+            </ControlTemplate>
         </Setter>
     </ControlTheme>
 
-    <ControlTheme x:Key="{x:Type TabStripItem}" TargetType="TabStripItem">
-        <Setter Property="Background" Value="{DynamicResource TabItemLinePipeBackground}" />
+    <ControlTheme
+        x:Key="ButtonTabStrip"
+        BasedOn="{StaticResource {x:Type TabStrip}}"
+        TargetType="TabStrip">
+        <Setter Property="ItemContainerTheme" Value="{StaticResource ButtonTabStripItem}" />
+        <Style Selector="^ /template/ Border#PART_BorderSeparator">
+            <Setter Property="IsVisible" Value="False" />
+        </Style>
+    </ControlTheme>
+
+
+    <ControlTheme x:Key="BaseTabStripItem" TargetType="TabStripItem">
         <Setter Property="Foreground" Value="{DynamicResource TabItemLineHeaderForeground}" />
-        <Setter Property="Margin" Value="0" />
-        <Setter Property="Padding" Value="8 4" />
-        <Setter Property="MinHeight" Value="5" />
-        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Background" Value="{DynamicResource TabItemLinePipeBackground}" />
         <Setter Property="Template">
             <ControlTemplate TargetType="TabStripItem">
-                <Border
-                    Name="PART_LayoutRoot"
+                <ContentPresenter
+                    Name="PART_ContentPresenter"
+                    Padding="{TemplateBinding Padding}"
+                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                    VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                     Background="{TemplateBinding Background}"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}"
-                    CornerRadius="{TemplateBinding CornerRadius}">
-                    <Panel>
-                        <ContentPresenter
-                            Name="PART_ContentPresenter"
-                            Margin="0,0,0,4"
-                            Padding="{TemplateBinding Padding}"
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Content="{TemplateBinding Content}"
-                            ContentTemplate="{TemplateBinding ContentTemplate}"
-                            FontFamily="{TemplateBinding FontFamily}"
-                            FontWeight="{TemplateBinding FontWeight}"
-                            Foreground="{TemplateBinding Foreground}" />
-                        <Border
-                            Name="PART_SelectedPipe"
-                            Height="2"
-                            Margin="0"
-                            HorizontalAlignment="Stretch"
-                            VerticalAlignment="Bottom"
-                            Background="{DynamicResource TabItemLinePipeBackground}"
-                            IsVisible="True"
-                            UseLayoutRounding="False" />
-                    </Panel>
-                </Border>
+                    Content="{TemplateBinding Content}"
+                    ContentTemplate="{TemplateBinding ContentTemplate}"
+                    CornerRadius="{TemplateBinding CornerRadius}"
+                    FontFamily="{TemplateBinding FontFamily}"
+                    FontWeight="{TemplateBinding FontWeight}"
+                    Foreground="{TemplateBinding Foreground}" />
             </ControlTemplate>
         </Setter>
 
-        <!--  Selected state  -->
         <Style Selector="^:selected /template/ ContentPresenter#PART_ContentPresenter">
-            <Setter Property="Foreground" Value="{DynamicResource TabItemLineHeaderSelectedForeground}" />
             <Setter Property="FontWeight" Value="{DynamicResource TabItemSelectedFontWeight}" />
+            <Setter Property="Foreground" Value="{DynamicResource TabItemLineHeaderSelectedForeground}" />
         </Style>
 
         <Style Selector="^:not(:selected)">
             <Setter Property="Cursor" Value="Hand" />
-            <Style Selector="^:pointerover /template/ Label#PART_ContentPresenter">
+            <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
                 <Setter Property="Foreground" Value="{DynamicResource TabItemLineHeaderPointeroverForeground}" />
             </Style>
-            <Style Selector="^:pointerover /template/ Border#PART_SelectedPipe">
-                <Setter Property="Background" Value="{DynamicResource TabItemLinePipePointeroverBorderBrush}" />
-            </Style>
-            <Style Selector="^:pressed /template/ Border#PART_SelectedPipe">
-                <Setter Property="Background" Value="{DynamicResource TabItemLinePipePressedBorderBrush}" />
-            </Style>
-        </Style>
-
-        <Style Selector="^:selected /template/ Border#PART_SelectedPipe">
-            <Setter Property="Background" Value="{DynamicResource TabItemLinePipeSelectedBackground}" />
-        </Style>
-
-        <!--  Selected Pressed state  -->
-        <Style Selector="^:selected:pressed /template/ Border#PART_LayoutRoot">
-            <Setter Property="Background" Value="{DynamicResource TabItemHeaderBackgroundSelectedPressed}" />
-            <Setter Property="TextElement.Foreground" Value="{DynamicResource TabItemHeaderForegroundSelectedPressed}" />
-        </Style>
-
-        <!--  Disabled state  -->
-        <Style Selector="^:disabled /template/ Border#PART_LayoutRoot">
-            <Setter Property="Background" Value="{DynamicResource TabItemHeaderBackgroundDisabled}" />
-            <Setter Property="TextElement.Foreground" Value="{DynamicResource TabItemHeaderForegroundDisabled}" />
         </Style>
     </ControlTheme>
+
+    <ControlTheme
+        x:Key="{x:Type TabStripItem}"
+        BasedOn="{StaticResource BaseTabStripItem}"
+        TargetType="TabStripItem">
+        <Setter Property="Padding" Value="8 4" />
+        <Setter Property="BorderThickness" Value="0 0 0 2" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Style Selector="^:selected /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="BorderBrush" Value="{DynamicResource TabItemLinePipeSelectedBackground}" />
+        </Style>
+
+        <Style Selector="^:not(:selected)">
+            <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="BorderBrush" Value="{DynamicResource TabItemLinePipePointeroverBorderBrush}" />
+            </Style>
+            <Style Selector="^:pressed /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="BorderBrush" Value="{DynamicResource TabItemLinePipePressedBorderBrush}" />
+            </Style>
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme
+        x:Key="LineTabStripItem"
+        BasedOn="{StaticResource BaseTabStripItem}"
+        TargetType="TabStripItem">
+        <Setter Property="Margin" Value="0 0 24 0" />
+        <Setter Property="Padding" Value="4 16 4 14" />
+        <Setter Property="BorderThickness" Value="0 0 0 2" />
+        <Style Selector="^:selected /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="BorderBrush" Value="{DynamicResource TabItemLinePipeSelectedBackground}" />
+        </Style>
+
+        <Style Selector="^:not(:selected)">
+            <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="BorderBrush" Value="{DynamicResource TabItemLinePipePointeroverBorderBrush}" />
+            </Style>
+            <Style Selector="^:pressed /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="BorderBrush" Value="{DynamicResource TabItemLinePipePressedBorderBrush}" />
+            </Style>
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme
+        x:Key="CardTabStripItem"
+        BasedOn="{StaticResource BaseTabStripItem}"
+        TargetType="TabStripItem">
+        <Setter Property="BorderBrush" Value="{DynamicResource TabControlSeparatorBorderBrush}" />
+        <Setter Property="Margin" Value="0 0 8 0" />
+        <Setter Property="MinHeight" Value="{DynamicResource TabItemCardDefaultHeight}" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Padding" Value="12 0" />
+        <Setter Property="CornerRadius" Value="3 3 0 0" />
+        <Style Selector="^:selected">
+            <Setter Property="BorderThickness" Value="1 1 1 0" />
+        </Style>
+        <Style Selector="^:selected /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource TabItemCardHeaderSelectedBackground}" />
+        </Style>
+
+        <Style Selector="^:not(:selected)">
+            <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Background" Value="{DynamicResource TabItemCardHeaderPointeroverBackground}" />
+            </Style>
+            <Style Selector="^:pressed /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Background" Value="{DynamicResource TabItemCardHeaderPressedBackground}" />
+            </Style>
+        </Style>
+    </ControlTheme>
+
+    <ControlTheme
+        x:Key="ButtonTabStripItem"
+        BasedOn="{StaticResource BaseTabStripItem}"
+        TargetType="TabStripItem">
+        <Setter Property="Margin" Value="0 0 8 0" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="MinHeight" Value="{DynamicResource TabItemCardDefaultHeight}" />
+        <Setter Property="Padding" Value="12 0" />
+        <Setter Property="CornerRadius" Value="{DynamicResource SemiBorderRadiusSmall}" />
+
+        <Style Selector="^:selected /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Foreground" Value="{DynamicResource TabItemButtonHeaderSelectedForeground}" />
+            <Setter Property="Background" Value="{DynamicResource TabItemButtonHeaderSelectedBackground}" />
+        </Style>
+
+        <Style Selector="^:not(:selected)">
+            <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Background" Value="{DynamicResource TabItemButtonHeaderPointeroverBackground}" />
+            </Style>
+            <Style Selector="^:pressed /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Background" Value="{DynamicResource TabItemButtonHeaderPressedBackground}" />
+            </Style>
+        </Style>
+    </ControlTheme>
+
 </ResourceDictionary>

--- a/src/Semi.Avalonia/Styles/TabStrip.axaml
+++ b/src/Semi.Avalonia/Styles/TabStrip.axaml
@@ -1,0 +1,5 @@
+﻿<Styles xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Style Selector="TabStrip TabStripItem:nth-last-child(1)">
+        <Setter Property="Margin" Value="0" />
+    </Style>
+</Styles>

--- a/src/Semi.Avalonia/Styles/_index.axaml
+++ b/src/Semi.Avalonia/Styles/_index.axaml
@@ -1,3 +1,4 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <StyleInclude Source="avares://Semi.Avalonia/Styles/TabControl.axaml" />
+    <StyleInclude Source="avares://Semi.Avalonia/Styles/TabStrip.axaml" />
 </Styles>


### PR DESCRIPTION
This pull request introduces a new `TabStripDemo` page and its associated view model in the demo application, along with several enhancements to the `TabStrip` control. The changes include adding new XAML and C# files for the demo, updating the main view to include the new demo page, and enhancing the `TabStrip` control with new themes and design previews.

### New `TabStripDemo` Page and ViewModel:

* [`demo/Semi.Avalonia.Demo/Pages/TabStripDemo.axaml`](diffhunk://#diff-67096b5a71a817aef7851b7b0fa4ae86c99cdef4ced19cac4dcb5a6093565367R1-R93): Added a new XAML file to define the layout and content of the `TabStripDemo` page, including various `TabStrip` themes.
* [`demo/Semi.Avalonia.Demo/Pages/TabStripDemo.axaml.cs`](diffhunk://#diff-ac7be42bc690c423194c79f1d28eb6ee40c556a47b8246270ac2f0122e0deaeeR1-R13): Added a new code-behind file to initialize the `TabStripDemo` page and set its data context to `TabStripDemoViewModel`.
* [`demo/Semi.Avalonia.Demo/ViewModels/TabStripDemoViewModel.cs`](diffhunk://#diff-7a5f88da18f2d204d0086e5b1106c738a06c9bf62c61aea24bea04f34c1cfd4dR1-R10): Added a new view model class to provide data for the `TabStripDemo` page, including an observable collection of tab items.

### Updates to Main View:

* [`demo/Semi.Avalonia.Demo/Views/MainView.axaml`](diffhunk://#diff-bad474798fe7d2216f1893dbe09d9a0e1b6b6881fefb288aee44cb1152bc581cR222-R224): Updated the main view to include a new tab item for the `TabStripDemo` page.

### Enhancements to `TabStrip` Control:

* [`src/Semi.Avalonia/Controls/TabStrip.axaml`](diffhunk://#diff-a9af733bf7c0aeedddb6200cc7bb775df4ae8b3fb38fb8e80a2047e1e3616b56R5-R215): Enhanced the `TabStrip` control with new themes (`LineTabStrip`, `CardTabStrip`, `ButtonTabStrip`) and a design preview for better visualization during development.