### PR TITLE
replace Label color resources & alter some tokens

### DIFF
--- a/src/Semi.Avalonia.ColorPicker/Dark.axaml
+++ b/src/Semi.Avalonia.ColorPicker/Dark.axaml
@@ -1,4 +1,7 @@
-<ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<ResourceDictionary
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:semi="https://irihi.tech/semi">
     <StaticResource x:Key="ColorViewRadioButtonForeground" ResourceKey="SemiColorPrimary" />
     <StaticResource x:Key="ColorViewRadioButtonBackground" ResourceKey="SemiColorBackground0" />
     <StaticResource x:Key="ColorViewRadioButtonPointeroverBackground" ResourceKey="SemiColorFill1" />
@@ -14,4 +17,5 @@
     <StaticResource x:Key="ColorSpectrumBorderBrush" ResourceKey="SemiColorBorder" />
     <StaticResource x:Key="ColorPreviewerMainBoxShadow" ResourceKey="SemiShadowElevated" />
     <BoxShadows x:Key="ColorSliderBoxShadow">0 0 2 1 #FFFFFF</BoxShadows>
+    <semi:SemiColorDarkPalette x:Key="SemiColorPalette" />
 </ResourceDictionary>

--- a/src/Semi.Avalonia.ColorPicker/Light.axaml
+++ b/src/Semi.Avalonia.ColorPicker/Light.axaml
@@ -1,4 +1,7 @@
-<ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<ResourceDictionary
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:semi="https://irihi.tech/semi">
     <StaticResource x:Key="ColorViewRadioButtonForeground" ResourceKey="SemiColorPrimary" />
     <StaticResource x:Key="ColorViewRadioButtonBackground" ResourceKey="SemiColorBackground0" />
     <StaticResource x:Key="ColorViewRadioButtonPointeroverBackground" ResourceKey="SemiColorFill1" />
@@ -14,4 +17,5 @@
     <StaticResource x:Key="ColorSpectrumBorderBrush" ResourceKey="SemiColorBorder" />
     <StaticResource x:Key="ColorPreviewerMainBoxShadow" ResourceKey="SemiShadowElevated" />
     <BoxShadows x:Key="ColorSliderBoxShadow">0 0 2 1 #FFFFFF</BoxShadows>
+    <semi:SemiColorLightPalette x:Key="SemiColorPalette" />
 </ResourceDictionary>

--- a/src/Semi.Avalonia.ColorPicker/SemiColorLightPalette.cs
+++ b/src/Semi.Avalonia.ColorPicker/SemiColorLightPalette.cs
@@ -80,7 +80,7 @@ public class SemiColorLightPalette: IColorPalette
             Color.FromUInt32(0xFF98CDFD),
             Color.FromUInt32(0xFF65B2FC),
             Color.FromUInt32(0xFF3295FB),
-            Color.FromUInt32(0xFF0077FA),
+            Color.FromUInt32(0xFF0064FA),
             Color.FromUInt32(0xFF0062D6),
             Color.FromUInt32(0xFF004FB3),
             Color.FromUInt32(0xFF003D8F),

--- a/src/Semi.Avalonia.ColorPicker/Shared.axaml
+++ b/src/Semi.Avalonia.ColorPicker/Shared.axaml
@@ -1,7 +1,6 @@
 ﻿<ResourceDictionary
     xmlns="https://github.com/avaloniaui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:semi="https://irihi.tech/semi">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <StaticResource x:Key="ColorViewRadioButtonFontWeight" ResourceKey="SemiFontWeightBold" />
     <Thickness x:Key="ColorViewRadioButtonPadding">16 4</Thickness>
     <x:Double x:Key="ColorViewNumericUpDownWidth">70</x:Double>
@@ -19,8 +18,6 @@
     <x:Double x:Key="ColorPreviewerAccentSectionHeight">20</x:Double>
     <x:Double x:Key="ColorPreviewerHeight">48</x:Double>
     <StaticResource x:Key="ColorPreviewerCornerRadius" ResourceKey="SemiBorderRadiusSmall" />
-
-    <semi:SemiColorDarkPalette x:Key="SemiColorPalette" />
 
     <StaticResource x:Key="ColorSpectrumCornerRadius" ResourceKey="SemiBorderRadiusMedium" />
 

--- a/src/Semi.Avalonia/Controls/Label.axaml
+++ b/src/Semi.Avalonia/Controls/Label.axaml
@@ -266,11 +266,6 @@
                 <Setter Property="Background" Value="{DynamicResource LabelTagLightGreyBackground}" />
                 <Setter Property="Foreground" Value="{DynamicResource LabelTagLightGreyForeground}" />
             </Style>
-            <Style Selector="^.White">
-                <Setter Property="Background" Value="{DynamicResource LabelTagLightWhiteBackground}" />
-                <Setter Property="Foreground" Value="{DynamicResource LabelTagLightWhiteForeground}" />
-                <Setter Property="BorderBrush" Value="{DynamicResource LabelTagLightWhiteBorderBrush}" />
-            </Style>
         </Style>
         <Style Selector="^.Ghost">
             <Setter Property="Background" Value="Transparent" />
@@ -340,11 +335,6 @@
                 <Setter Property="BorderBrush" Value="{DynamicResource LabelTagGhostGreyBorderBrush}" />
                 <Setter Property="Foreground" Value="{DynamicResource LabelTagGhostGreyForeground}" />
             </Style>
-            <Style Selector="^.White">
-                <Setter Property="Background" Value="{DynamicResource LabelTagGhostWhiteBackground}" />
-                <Setter Property="Foreground" Value="{DynamicResource LabelTagGhostWhiteForeground}" />
-                <Setter Property="BorderBrush" Value="{DynamicResource LabelTagGhostWhiteBorderBrush}" />
-            </Style>
         </Style>
         <Style Selector="^.Solid">
             <Setter Property="BorderBrush" Value="Transparent" />
@@ -398,11 +388,12 @@
             <Style Selector="^.Grey">
                 <Setter Property="Background" Value="{DynamicResource LabelTagSolidGreyBackground}" />
             </Style>
-            <Style Selector="^.White">
-                <Setter Property="Foreground" Value="{DynamicResource LabelTagSolidWhiteForeground}" />
-                <Setter Property="BorderBrush" Value="{DynamicResource LabelTagSolidWhiteBorderBrush}" />
-                <Setter Property="Background" Value="{DynamicResource LabelTagSolidWhiteBackground}" />
-            </Style>
+        </Style>
+
+        <Style Selector="^.White">
+            <Setter Property="Foreground" Value="{DynamicResource LabelTagSolidWhiteForeground}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource LabelTagSolidWhiteBorderBrush}" />
+            <Setter Property="Background" Value="{DynamicResource LabelTagSolidWhiteBackground}" />
         </Style>
     </ControlTheme>
 </ResourceDictionary>

--- a/src/Semi.Avalonia/Themes/Dark/Label.axaml
+++ b/src/Semi.Avalonia/Themes/Dark/Label.axaml
@@ -1,96 +1,100 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <!--  Typography related resources are combined with TextBlock  -->
-    <SolidColorBrush x:Key="LabelTagLightRedForeground" Color="#FEE0D5" />
-    <SolidColorBrush x:Key="LabelTagLightRedBackground" Opacity="0.15" Color="#FC725A" />
-    <SolidColorBrush x:Key="LabelTagLightPinkForeground" Color="#FBD3DC" />
-    <SolidColorBrush x:Key="LabelTagLightPinkBackground" Opacity="0.15" Color="#EF5686" />
-    <SolidColorBrush x:Key="LabelTagLightPurpleForeground" Color="#EFCEF0" />
-    <SolidColorBrush x:Key="LabelTagLightPurpleBackground" Opacity="0.15" Color="#B553C2" />
-    <SolidColorBrush x:Key="LabelTagLightVioletForeground" Color="#DDD4F4" />
-    <SolidColorBrush x:Key="LabelTagLightVioletBackground" Opacity="0.15" Color="#8865D4" />
-    <SolidColorBrush x:Key="LabelTagLightIndigoForeground" Color="#D1D8F1" />
-    <SolidColorBrush x:Key="LabelTagLightIndigoBackground" Opacity="0.15" Color="#5F71C5" />
-    <SolidColorBrush x:Key="LabelTagLightBlueForeground" Color="#D4ECFF" />
-    <SolidColorBrush x:Key="LabelTagLightBlueBackground" Opacity="0.15" Color="#54A9FF" />
-    <SolidColorBrush x:Key="LabelTagLightLightBlueForeground" Color="#CEEEFC" />
-    <SolidColorBrush x:Key="LabelTagLightLightBlueBackground" Opacity="0.15" Color="#40B4F3" />
-    <SolidColorBrush x:Key="LabelTagLightCyanForeground" Color="#C6EFF1" />
-    <SolidColorBrush x:Key="LabelTagLightCyanBackground" Opacity="0.15" Color="#38BBC6" />
-    <SolidColorBrush x:Key="LabelTagLightTealForeground" Color="#C4F0E8" />
-    <SolidColorBrush x:Key="LabelTagLightTealBackground" Opacity="0.15" Color="#33C2B0" />
-    <SolidColorBrush x:Key="LabelTagLightGreenForeground" Color="#D0F0D1" />
-    <SolidColorBrush x:Key="LabelTagLightGreenBackground" Opacity="0.15" Color="#5DC264" />
-    <SolidColorBrush x:Key="LabelTagLightLightGreenForeground" Color="#E4F1D1" />
-    <SolidColorBrush x:Key="LabelTagLightLightGreenBackground" Opacity="0.15" Color="#97C65F" />
-    <SolidColorBrush x:Key="LabelTagLightLimeForeground" Color="#E5F6C9" />
-    <SolidColorBrush x:Key="LabelTagLightLimeBackground" Opacity="0.15" Color="#AEDC3A" />
-    <SolidColorBrush x:Key="LabelTagLightYellowForeground" Color="#FEFBD0" />
-    <SolidColorBrush x:Key="LabelTagLightYellowBackground" Opacity="0.15" Color="#FDDE43" />
-    <SolidColorBrush x:Key="LabelTagLightAmberForeground" Color="#FCF6D2" />
-    <SolidColorBrush x:Key="LabelTagLightAmberBackground" Opacity="0.15" Color="#F5CA50" />
-    <SolidColorBrush x:Key="LabelTagLightOrangeForeground" Color="#FFEFD0" />
-    <SolidColorBrush x:Key="LabelTagLightOrangeBackground" Opacity="0.15" Color="#FFAE43" />
-    <SolidColorBrush x:Key="LabelTagLightGreyForeground" Color="#E6E8EA" />
-    <SolidColorBrush x:Key="LabelTagLightGreyBackground" Opacity="0.15" Color="#888D92" />
-    <SolidColorBrush x:Key="LabelTagLightWhiteBackground" Color="#4F5159" />
-    <SolidColorBrush x:Key="LabelTagLightWhiteBorderBrush" Color="#41464C" />
-    <SolidColorBrush x:Key="LabelTagLightWhiteForeground" Color="#F9F9F9" />
+    <StaticResource x:Key="LabelTagLightRedForeground" ResourceKey="SemiRed8" />
+    <SolidColorBrush x:Key="LabelTagLightRedBackground" Opacity="0.15" Color="{StaticResource SemiRed5Color}" />
+    <StaticResource x:Key="LabelTagLightPinkForeground" ResourceKey="SemiPink8" />
+    <SolidColorBrush x:Key="LabelTagLightPinkBackground" Opacity="0.15" Color="{StaticResource SemiPink5Color}" />
+    <StaticResource x:Key="LabelTagLightPurpleForeground" ResourceKey="SemiPurple8" />
+    <SolidColorBrush x:Key="LabelTagLightPurpleBackground" Opacity="0.15" Color="{StaticResource SemiPurple5Color}" />
+    <StaticResource x:Key="LabelTagLightVioletForeground" ResourceKey="SemiViolet8" />
+    <SolidColorBrush x:Key="LabelTagLightVioletBackground" Opacity="0.15" Color="{StaticResource SemiViolet5Color}" />
+    <StaticResource x:Key="LabelTagLightIndigoForeground" ResourceKey="SemiIndigo8" />
+    <SolidColorBrush x:Key="LabelTagLightIndigoBackground" Opacity="0.15" Color="{StaticResource SemiIndigo5Color}" />
+    <StaticResource x:Key="LabelTagLightBlueForeground" ResourceKey="SemiBlue8" />
+    <SolidColorBrush x:Key="LabelTagLightBlueBackground" Opacity="0.15" Color="{StaticResource SemiBlue5Color}" />
+    <StaticResource x:Key="LabelTagLightLightBlueForeground" ResourceKey="SemiLightBlue8" />
+    <SolidColorBrush x:Key="LabelTagLightLightBlueBackground" Opacity="0.15" Color="{StaticResource SemiLightBlue5Color}" />
+    <StaticResource x:Key="LabelTagLightCyanForeground" ResourceKey="SemiCyan8" />
+    <SolidColorBrush x:Key="LabelTagLightCyanBackground" Opacity="0.15" Color="{StaticResource SemiCyan5Color}" />
+    <StaticResource x:Key="LabelTagLightTealForeground" ResourceKey="SemiTeal8" />
+    <SolidColorBrush x:Key="LabelTagLightTealBackground" Opacity="0.15" Color="{StaticResource SemiTeal5Color}" />
+    <StaticResource x:Key="LabelTagLightGreenForeground" ResourceKey="SemiGreen8" />
+    <SolidColorBrush x:Key="LabelTagLightGreenBackground" Opacity="0.15" Color="{StaticResource SemiGreen5Color}" />
+    <StaticResource x:Key="LabelTagLightLightGreenForeground" ResourceKey="SemiLightGreen8" />
+    <SolidColorBrush x:Key="LabelTagLightLightGreenBackground" Opacity="0.15" Color="{StaticResource SemiLightGreen5Color}" />
+    <StaticResource x:Key="LabelTagLightLimeForeground" ResourceKey="SemiLime8" />
+    <SolidColorBrush x:Key="LabelTagLightLimeBackground" Opacity="0.15" Color="{StaticResource SemiLime5Color}" />
+    <StaticResource x:Key="LabelTagLightYellowForeground" ResourceKey="SemiYellow8" />
+    <SolidColorBrush x:Key="LabelTagLightYellowBackground" Opacity="0.15" Color="{StaticResource SemiYellow5Color}" />
+    <StaticResource x:Key="LabelTagLightAmberForeground" ResourceKey="SemiAmber8" />
+    <SolidColorBrush x:Key="LabelTagLightAmberBackground" Opacity="0.15" Color="{StaticResource SemiAmber5Color}" />
+    <StaticResource x:Key="LabelTagLightOrangeForeground" ResourceKey="SemiOrange8" />
+    <SolidColorBrush x:Key="LabelTagLightOrangeBackground" Opacity="0.15" Color="{StaticResource SemiOrange5Color}" />
+    <StaticResource x:Key="LabelTagLightGreyForeground" ResourceKey="SemiGrey8" />
+    <SolidColorBrush x:Key="LabelTagLightGreyBackground" Opacity="0.15" Color="{StaticResource SemiGrey5Color}" />
 
-    <SolidColorBrush x:Key="LabelTagGhostRedBorderBrush" Color="#FB4932" />
-    <SolidColorBrush x:Key="LabelTagGhostRedForeground" Color="#FC725A" />
-    <SolidColorBrush x:Key="LabelTagGhostPinkBorderBrush" Color="#EB2F71" />
-    <SolidColorBrush x:Key="LabelTagGhostPinkForeground" Color="#EF5686" />
-    <SolidColorBrush x:Key="LabelTagGhostPurpleBorderBrush" Color="#A033B3" />
-    <SolidColorBrush x:Key="LabelTagGhostPurpleForeground" Color="#B553C2" />
-    <SolidColorBrush x:Key="LabelTagGhostVioletBorderBrush" Color="#7246C9" />
-    <SolidColorBrush x:Key="LabelTagGhostVioletForeground" Color="#8865D4" />
-    <SolidColorBrush x:Key="LabelTagGhostIndigoBorderBrush" Color="#4053B7" />
-    <SolidColorBrush x:Key="LabelTagGhostIndigoForeground" Color="#5F71C5" />
-    <SolidColorBrush x:Key="LabelTagGhostBlueBorderBrush" Color="#2990FF" />
-    <SolidColorBrush x:Key="LabelTagGhostBlueForeground" Color="#54A9FF" />
-    <SolidColorBrush x:Key="LabelTagGhostLightBlueBorderBrush" Color="#139FF0" />
-    <SolidColorBrush x:Key="LabelTagGhostLightBlueForeground" Color="#40B4F3" />
-    <SolidColorBrush x:Key="LabelTagGhostCyanBorderBrush" Color="#13A8B8" />
-    <SolidColorBrush x:Key="LabelTagGhostCyanForeground" Color="#38BBC6" />
-    <SolidColorBrush x:Key="LabelTagGhostTealBorderBrush" Color="#0EB3A1" />
-    <SolidColorBrush x:Key="LabelTagGhostTealForeground" Color="#33C2B0" />
-    <SolidColorBrush x:Key="LabelTagGhostGreenBorderBrush" Color="#3EB349" />
-    <SolidColorBrush x:Key="LabelTagGhostGreenForeground" Color="#5DC264" />
-    <SolidColorBrush x:Key="LabelTagGhostLightGreenBorderBrush" Color="#7FB840" />
-    <SolidColorBrush x:Key="LabelTagGhostLightGreenForeground" Color="#97C65F" />
-    <SolidColorBrush x:Key="LabelTagGhostLimeBorderBrush" Color="#A2D311" />
-    <SolidColorBrush x:Key="LabelTagGhostLimeForeground" Color="#AEDC3A" />
-    <SolidColorBrush x:Key="LabelTagGhostYellowBorderBrush" Color="#FCCE14" />
-    <SolidColorBrush x:Key="LabelTagGhostYellowForeground" Color="#FDDE43" />
-    <SolidColorBrush x:Key="LabelTagGhostAmberBorderBrush" Color="#F2B726" />
-    <SolidColorBrush x:Key="LabelTagGhostAmberForeground" Color="#F5CA50" />
-    <SolidColorBrush x:Key="LabelTagGhostOrangeBorderBrush" Color="#FF9214" />
-    <SolidColorBrush x:Key="LabelTagGhostOrangeForeground" Color="#FFAE43" />
-    <SolidColorBrush x:Key="LabelTagGhostGreyBorderBrush" Color="#6B7075" />
-    <SolidColorBrush x:Key="LabelTagGhostGreyForeground" Color="#888D92" />
-    <SolidColorBrush x:Key="LabelTagGhostWhiteBackground" Color="#4F5159" />
-    <SolidColorBrush x:Key="LabelTagGhostWhiteBorderBrush" Color="#41464C" />
-    <SolidColorBrush x:Key="LabelTagGhostWhiteForeground" Color="#F9F9F9" />
+    <StaticResource x:Key="LabelTagLightWhiteForeground" ResourceKey="SemiColorText0" />
+    <StaticResource x:Key="LabelTagLightWhiteBackground" ResourceKey="SemiColorBackground4" />
+    <SolidColorBrush x:Key="LabelTagLightWhiteBorderBrush" Opacity="0.7" Color="{StaticResource SemiGrey2Color}" />
 
-    <SolidColorBrush x:Key="LabelTagSolidForeground" Color="White" />
-    <SolidColorBrush x:Key="LabelTagSolidRedBackground" Color="#FC725A" />
-    <SolidColorBrush x:Key="LabelTagSolidPinkBackground" Color="#EF5686" />
-    <SolidColorBrush x:Key="LabelTagSolidPurpleBackground" Color="#B553C2" />
-    <SolidColorBrush x:Key="LabelTagSolidVioletBackground" Color="#8865D4" />
-    <SolidColorBrush x:Key="LabelTagSolidIndigoBackground" Color="#5F71C5" />
-    <SolidColorBrush x:Key="LabelTagSolidBlueBackground" Color="#54A9FF" />
-    <SolidColorBrush x:Key="LabelTagSolidLightBlueBackground" Color="#40B4F3" />
-    <SolidColorBrush x:Key="LabelTagSolidCyanBackground" Color="#38BBC6" />
-    <SolidColorBrush x:Key="LabelTagSolidTealBackground" Color="#33C2B0" />
-    <SolidColorBrush x:Key="LabelTagSolidGreenBackground" Color="#5DC264" />
-    <SolidColorBrush x:Key="LabelTagSolidLightGreenBackground" Color="#97C65F" />
-    <SolidColorBrush x:Key="LabelTagSolidLimeBackground" Color="#AEDC3A" />
-    <SolidColorBrush x:Key="LabelTagSolidYellowBackground" Color="#FDDE43" />
-    <SolidColorBrush x:Key="LabelTagSolidAmberBackground" Color="#F5CA50" />
-    <SolidColorBrush x:Key="LabelTagSolidOrangeBackground" Color="#FFAE43" />
-    <SolidColorBrush x:Key="LabelTagSolidGreyBackground" Color="#888D92" />
 
-    <SolidColorBrush x:Key="LabelTagSolidWhiteBackground" Color="#4F5159" />
-    <SolidColorBrush x:Key="LabelTagSolidWhiteBorderBrush" Color="#41464C" />
-    <SolidColorBrush x:Key="LabelTagSolidWhiteForeground" Color="#F9F9F9" />
+    <StaticResource x:Key="LabelTagGhostRedBorderBrush" ResourceKey="SemiRed4" />
+    <StaticResource x:Key="LabelTagGhostRedForeground" ResourceKey="SemiRed5" />
+    <StaticResource x:Key="LabelTagGhostPinkBorderBrush" ResourceKey="SemiPink4" />
+    <StaticResource x:Key="LabelTagGhostPinkForeground" ResourceKey="SemiPink5" />
+    <StaticResource x:Key="LabelTagGhostPurpleBorderBrush" ResourceKey="SemiPurple4" />
+    <StaticResource x:Key="LabelTagGhostPurpleForeground" ResourceKey="SemiPurple5" />
+    <StaticResource x:Key="LabelTagGhostVioletBorderBrush" ResourceKey="SemiViolet4" />
+    <StaticResource x:Key="LabelTagGhostVioletForeground" ResourceKey="SemiViolet5" />
+    <StaticResource x:Key="LabelTagGhostIndigoBorderBrush" ResourceKey="SemiIndigo4" />
+    <StaticResource x:Key="LabelTagGhostIndigoForeground" ResourceKey="SemiIndigo5" />
+    <StaticResource x:Key="LabelTagGhostBlueBorderBrush" ResourceKey="SemiBlue4" />
+    <StaticResource x:Key="LabelTagGhostBlueForeground" ResourceKey="SemiBlue5" />
+    <StaticResource x:Key="LabelTagGhostLightBlueBorderBrush" ResourceKey="SemiLightBlue4" />
+    <StaticResource x:Key="LabelTagGhostLightBlueForeground" ResourceKey="SemiLightBlue5" />
+    <StaticResource x:Key="LabelTagGhostCyanBorderBrush" ResourceKey="SemiCyan4" />
+    <StaticResource x:Key="LabelTagGhostCyanForeground" ResourceKey="SemiCyan5" />
+    <StaticResource x:Key="LabelTagGhostTealBorderBrush" ResourceKey="SemiTeal4" />
+    <StaticResource x:Key="LabelTagGhostTealForeground" ResourceKey="SemiTeal5" />
+    <StaticResource x:Key="LabelTagGhostGreenBorderBrush" ResourceKey="SemiGreen4" />
+    <StaticResource x:Key="LabelTagGhostGreenForeground" ResourceKey="SemiGreen5" />
+    <StaticResource x:Key="LabelTagGhostLightGreenBorderBrush" ResourceKey="SemiLightGreen4" />
+    <StaticResource x:Key="LabelTagGhostLightGreenForeground" ResourceKey="SemiLightGreen5" />
+    <StaticResource x:Key="LabelTagGhostLimeBorderBrush" ResourceKey="SemiLime4" />
+    <StaticResource x:Key="LabelTagGhostLimeForeground" ResourceKey="SemiLime5" />
+    <StaticResource x:Key="LabelTagGhostYellowBorderBrush" ResourceKey="SemiYellow4" />
+    <StaticResource x:Key="LabelTagGhostYellowForeground" ResourceKey="SemiYellow5" />
+    <StaticResource x:Key="LabelTagGhostAmberBorderBrush" ResourceKey="SemiAmber4" />
+    <StaticResource x:Key="LabelTagGhostAmberForeground" ResourceKey="SemiAmber5" />
+    <StaticResource x:Key="LabelTagGhostOrangeBorderBrush" ResourceKey="SemiOrange4" />
+    <StaticResource x:Key="LabelTagGhostOrangeForeground" ResourceKey="SemiOrange5" />
+    <StaticResource x:Key="LabelTagGhostGreyBorderBrush" ResourceKey="SemiGrey4" />
+    <StaticResource x:Key="LabelTagGhostGreyForeground" ResourceKey="SemiGrey5" />
+
+    <StaticResource x:Key="LabelTagGhostWhiteForeground" ResourceKey="SemiColorText0" />
+    <StaticResource x:Key="LabelTagGhostWhiteBackground" ResourceKey="SemiColorBackground4" />
+    <SolidColorBrush x:Key="LabelTagGhostWhiteBorderBrush" Opacity="0.7" Color="{StaticResource SemiGrey2Color}" />
+
+
+    <StaticResource x:Key="LabelTagSolidForeground" ResourceKey="SemiWhite" />
+    <StaticResource x:Key="LabelTagSolidRedBackground" ResourceKey="SemiRed5" />
+    <StaticResource x:Key="LabelTagSolidPinkBackground" ResourceKey="SemiPink5" />
+    <StaticResource x:Key="LabelTagSolidPurpleBackground" ResourceKey="SemiPurple5" />
+    <StaticResource x:Key="LabelTagSolidVioletBackground" ResourceKey="SemiViolet5" />
+    <StaticResource x:Key="LabelTagSolidIndigoBackground" ResourceKey="SemiIndigo5" />
+    <StaticResource x:Key="LabelTagSolidBlueBackground" ResourceKey="SemiBlue5" />
+    <StaticResource x:Key="LabelTagSolidLightBlueBackground" ResourceKey="SemiLightBlue5" />
+    <StaticResource x:Key="LabelTagSolidCyanBackground" ResourceKey="SemiCyan5" />
+    <StaticResource x:Key="LabelTagSolidTealBackground" ResourceKey="SemiTeal5" />
+    <StaticResource x:Key="LabelTagSolidGreenBackground" ResourceKey="SemiGreen5" />
+    <StaticResource x:Key="LabelTagSolidLightGreenBackground" ResourceKey="SemiLightGreen5" />
+    <StaticResource x:Key="LabelTagSolidLimeBackground" ResourceKey="SemiLime5" />
+    <StaticResource x:Key="LabelTagSolidYellowBackground" ResourceKey="SemiYellow5" />
+    <StaticResource x:Key="LabelTagSolidAmberBackground" ResourceKey="SemiAmber5" />
+    <StaticResource x:Key="LabelTagSolidOrangeBackground" ResourceKey="SemiOrange5" />
+    <StaticResource x:Key="LabelTagSolidGreyBackground" ResourceKey="SemiGrey5" />
+
+    <StaticResource x:Key="LabelTagSolidWhiteForeground" ResourceKey="SemiColorText0" />
+    <StaticResource x:Key="LabelTagSolidWhiteBackground" ResourceKey="SemiColorBackground4" />
+    <SolidColorBrush x:Key="LabelTagSolidWhiteBorderBrush" Opacity="0.7" Color="{StaticResource SemiGrey2Color}" />
 </ResourceDictionary>

--- a/src/Semi.Avalonia/Themes/Dark/Label.axaml
+++ b/src/Semi.Avalonia/Themes/Dark/Label.axaml
@@ -33,11 +33,6 @@
     <StaticResource x:Key="LabelTagLightGreyForeground" ResourceKey="SemiGrey8" />
     <SolidColorBrush x:Key="LabelTagLightGreyBackground" Opacity="0.15" Color="{StaticResource SemiGrey5Color}" />
 
-    <StaticResource x:Key="LabelTagLightWhiteForeground" ResourceKey="SemiColorText0" />
-    <StaticResource x:Key="LabelTagLightWhiteBackground" ResourceKey="SemiColorBackground4" />
-    <SolidColorBrush x:Key="LabelTagLightWhiteBorderBrush" Opacity="0.7" Color="{StaticResource SemiGrey2Color}" />
-
-
     <StaticResource x:Key="LabelTagGhostRedBorderBrush" ResourceKey="SemiRed4" />
     <StaticResource x:Key="LabelTagGhostRedForeground" ResourceKey="SemiRed5" />
     <StaticResource x:Key="LabelTagGhostPinkBorderBrush" ResourceKey="SemiPink4" />
@@ -71,11 +66,6 @@
     <StaticResource x:Key="LabelTagGhostGreyBorderBrush" ResourceKey="SemiGrey4" />
     <StaticResource x:Key="LabelTagGhostGreyForeground" ResourceKey="SemiGrey5" />
 
-    <StaticResource x:Key="LabelTagGhostWhiteForeground" ResourceKey="SemiColorText0" />
-    <StaticResource x:Key="LabelTagGhostWhiteBackground" ResourceKey="SemiColorBackground4" />
-    <SolidColorBrush x:Key="LabelTagGhostWhiteBorderBrush" Opacity="0.7" Color="{StaticResource SemiGrey2Color}" />
-
-
     <StaticResource x:Key="LabelTagSolidForeground" ResourceKey="SemiWhite" />
     <StaticResource x:Key="LabelTagSolidRedBackground" ResourceKey="SemiRed5" />
     <StaticResource x:Key="LabelTagSolidPinkBackground" ResourceKey="SemiPink5" />
@@ -97,4 +87,12 @@
     <StaticResource x:Key="LabelTagSolidWhiteForeground" ResourceKey="SemiColorText0" />
     <StaticResource x:Key="LabelTagSolidWhiteBackground" ResourceKey="SemiColorBackground4" />
     <SolidColorBrush x:Key="LabelTagSolidWhiteBorderBrush" Opacity="0.7" Color="{StaticResource SemiGrey2Color}" />
+
+    <!-- Obsolete -->
+    <StaticResource x:Key="LabelTagLightWhiteForeground" ResourceKey="LabelTagSolidWhiteForeground" />
+    <StaticResource x:Key="LabelTagLightWhiteBackground" ResourceKey="LabelTagSolidWhiteBackground" />
+    <StaticResource x:Key="LabelTagLightWhiteBorderBrush" ResourceKey="LabelTagSolidWhiteBorderBrush" />
+    <StaticResource x:Key="LabelTagGhostWhiteForeground" ResourceKey="LabelTagSolidWhiteForeground" />
+    <StaticResource x:Key="LabelTagGhostWhiteBackground" ResourceKey="LabelTagSolidWhiteBackground" />
+    <StaticResource x:Key="LabelTagGhostWhiteBorderBrush" ResourceKey="LabelTagSolidWhiteBorderBrush" />
 </ResourceDictionary>

--- a/src/Semi.Avalonia/Themes/Light/Label.axaml
+++ b/src/Semi.Avalonia/Themes/Light/Label.axaml
@@ -11,7 +11,7 @@
     <SolidColorBrush x:Key="LabelTagLightIndigoForeground" Color="#1F2878" />
     <SolidColorBrush x:Key="LabelTagLightIndigoBackground" Opacity="0.15" Color="#3F51B5" />
     <SolidColorBrush x:Key="LabelTagLightBlueForeground" Color="#003D8F" />
-    <SolidColorBrush x:Key="LabelTagLightBlueBackground" Opacity="0.15" Color="#0077FA" />
+    <SolidColorBrush x:Key="LabelTagLightBlueBackground" Opacity="0.15" Color="#0064FA" />
     <SolidColorBrush x:Key="LabelTagLightLightBlueForeground" Color="#004B83" />
     <SolidColorBrush x:Key="LabelTagLightLightBlueBackground" Opacity="0.15" Color="#0095EE" />
     <SolidColorBrush x:Key="LabelTagLightCyanForeground" Color="#004D5B" />
@@ -47,7 +47,7 @@
     <SolidColorBrush x:Key="LabelTagGhostIndigoBorderBrush" Color="#5E6FC4" />
     <SolidColorBrush x:Key="LabelTagGhostIndigoForeground" Color="#3F51B5" />
     <SolidColorBrush x:Key="LabelTagGhostBlueBorderBrush" Color="#3295FB" />
-    <SolidColorBrush x:Key="LabelTagGhostBlueForeground" Color="#0077FA" />
+    <SolidColorBrush x:Key="LabelTagGhostBlueForeground" Color="#0064FA" />
     <SolidColorBrush x:Key="LabelTagGhostLightBlueBorderBrush" Color="#30ACF1" />
     <SolidColorBrush x:Key="LabelTagGhostLightBlueForeground" Color="#0095EE" />
     <SolidColorBrush x:Key="LabelTagGhostCyanBorderBrush" Color="#2CB8C5" />
@@ -77,7 +77,7 @@
     <SolidColorBrush x:Key="LabelTagSolidPurpleBackground" Color="#9E28B3" />
     <SolidColorBrush x:Key="LabelTagSolidVioletBackground" Color="#6A3AC7" />
     <SolidColorBrush x:Key="LabelTagSolidIndigoBackground" Color="#3F51B5" />
-    <SolidColorBrush x:Key="LabelTagSolidBlueBackground" Color="#0077FA" />
+    <SolidColorBrush x:Key="LabelTagSolidBlueBackground" Color="#0064FA" />
     <SolidColorBrush x:Key="LabelTagSolidLightBlueBackground" Color="#0095EE" />
     <SolidColorBrush x:Key="LabelTagSolidCyanBackground" Color="#05A4B6" />
     <SolidColorBrush x:Key="LabelTagSolidTealBackground" Color="#00B3A1" />

--- a/src/Semi.Avalonia/Themes/Light/Label.axaml
+++ b/src/Semi.Avalonia/Themes/Light/Label.axaml
@@ -33,11 +33,6 @@
     <StaticResource x:Key="LabelTagLightGreyForeground" ResourceKey="SemiGrey8" />
     <SolidColorBrush x:Key="LabelTagLightGreyBackground" Opacity="0.15" Color="{StaticResource SemiGrey5Color}" />
 
-    <StaticResource x:Key="LabelTagLightWhiteForeground" ResourceKey="SemiColorText0" />
-    <StaticResource x:Key="LabelTagLightWhiteBackground" ResourceKey="SemiColorBackground4" />
-    <SolidColorBrush x:Key="LabelTagLightWhiteBorderBrush" Opacity="0.7" Color="{StaticResource SemiGrey2Color}" />
-
-
     <StaticResource x:Key="LabelTagGhostRedBorderBrush" ResourceKey="SemiRed4" />
     <StaticResource x:Key="LabelTagGhostRedForeground" ResourceKey="SemiRed5" />
     <StaticResource x:Key="LabelTagGhostPinkBorderBrush" ResourceKey="SemiPink4" />
@@ -71,11 +66,6 @@
     <StaticResource x:Key="LabelTagGhostGreyBorderBrush" ResourceKey="SemiGrey4" />
     <StaticResource x:Key="LabelTagGhostGreyForeground" ResourceKey="SemiGrey5" />
 
-    <StaticResource x:Key="LabelTagGhostWhiteForeground" ResourceKey="SemiColorText0" />
-    <StaticResource x:Key="LabelTagGhostWhiteBackground" ResourceKey="SemiColorBackground4" />
-    <SolidColorBrush x:Key="LabelTagGhostWhiteBorderBrush" Opacity="0.7" Color="{StaticResource SemiGrey2Color}" />
-
-
     <StaticResource x:Key="LabelTagSolidForeground" ResourceKey="SemiWhite" />
     <StaticResource x:Key="LabelTagSolidRedBackground" ResourceKey="SemiRed5" />
     <StaticResource x:Key="LabelTagSolidPinkBackground" ResourceKey="SemiPink5" />
@@ -97,4 +87,12 @@
     <StaticResource x:Key="LabelTagSolidWhiteForeground" ResourceKey="SemiColorText0" />
     <StaticResource x:Key="LabelTagSolidWhiteBackground" ResourceKey="SemiColorBackground4" />
     <SolidColorBrush x:Key="LabelTagSolidWhiteBorderBrush" Opacity="0.7" Color="{StaticResource SemiGrey2Color}" />
+
+    <!-- Obsolete -->
+    <StaticResource x:Key="LabelTagLightWhiteForeground" ResourceKey="LabelTagSolidWhiteForeground" />
+    <StaticResource x:Key="LabelTagLightWhiteBackground" ResourceKey="LabelTagSolidWhiteBackground" />
+    <StaticResource x:Key="LabelTagLightWhiteBorderBrush" ResourceKey="LabelTagSolidWhiteBorderBrush" />
+    <StaticResource x:Key="LabelTagGhostWhiteForeground" ResourceKey="LabelTagSolidWhiteForeground" />
+    <StaticResource x:Key="LabelTagGhostWhiteBackground" ResourceKey="LabelTagSolidWhiteBackground" />
+    <StaticResource x:Key="LabelTagGhostWhiteBorderBrush" ResourceKey="LabelTagSolidWhiteBorderBrush" />
 </ResourceDictionary>

--- a/src/Semi.Avalonia/Themes/Light/Label.axaml
+++ b/src/Semi.Avalonia/Themes/Light/Label.axaml
@@ -1,95 +1,100 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <!--  Typography related resources are combined with TextBlock  -->
-    <SolidColorBrush x:Key="LabelTagLightRedForeground" Color="#8E0805" />
-    <SolidColorBrush x:Key="LabelTagLightRedBackground" Opacity="0.15" Color="#F93920" />
-    <SolidColorBrush x:Key="LabelTagLightPinkForeground" Color="#7E053A" />
-    <SolidColorBrush x:Key="LabelTagLightPinkBackground" Opacity="0.15" Color="#E91E63" />
-    <SolidColorBrush x:Key="LabelTagLightPurpleForeground" Color="#5C0F75" />
-    <SolidColorBrush x:Key="LabelTagLightPurpleBackground" Opacity="0.15" Color="#9E28B3" />
-    <SolidColorBrush x:Key="LabelTagLightVioletForeground" Color="#6A3AC7" />
-    <SolidColorBrush x:Key="LabelTagLightVioletBackground" Opacity="0.15" Color="#361C8A" />
-    <SolidColorBrush x:Key="LabelTagLightIndigoForeground" Color="#1F2878" />
-    <SolidColorBrush x:Key="LabelTagLightIndigoBackground" Opacity="0.15" Color="#3F51B5" />
-    <SolidColorBrush x:Key="LabelTagLightBlueForeground" Color="#003D8F" />
-    <SolidColorBrush x:Key="LabelTagLightBlueBackground" Opacity="0.15" Color="#0064FA" />
-    <SolidColorBrush x:Key="LabelTagLightLightBlueForeground" Color="#004B83" />
-    <SolidColorBrush x:Key="LabelTagLightLightBlueBackground" Opacity="0.15" Color="#0095EE" />
-    <SolidColorBrush x:Key="LabelTagLightCyanForeground" Color="#004D5B" />
-    <SolidColorBrush x:Key="LabelTagLightCyanBackground" Opacity="0.15" Color="#05A4B6" />
-    <SolidColorBrush x:Key="LabelTagLightTealForeground" Color="#005955" />
-    <SolidColorBrush x:Key="LabelTagLightTealBackground" Opacity="0.15" Color="#00B3A1" />
-    <SolidColorBrush x:Key="LabelTagLightGreenForeground" Color="#1B5924" />
-    <SolidColorBrush x:Key="LabelTagLightGreenBackground" Opacity="0.15" Color="#3BB346" />
-    <SolidColorBrush x:Key="LabelTagLightLightGreenForeground" Color="#395B1B" />
-    <SolidColorBrush x:Key="LabelTagLightLightGreenBackground" Opacity="0.15" Color="#7BB63C" />
-    <SolidColorBrush x:Key="LabelTagLightLimeForeground" Color="#486800" />
-    <SolidColorBrush x:Key="LabelTagLightLimeBackground" Opacity="0.15" Color="#9BD100" />
-    <SolidColorBrush x:Key="LabelTagLightYellowForeground" Color="#7D6A00" />
-    <SolidColorBrush x:Key="LabelTagLightYellowBackground" Opacity="0.15" Color="#FAC800" />
-    <SolidColorBrush x:Key="LabelTagLightAmberForeground" Color="#784606" />
-    <SolidColorBrush x:Key="LabelTagLightAmberBackground" Opacity="0.15" Color="#F0B114" />
-    <SolidColorBrush x:Key="LabelTagLightOrangeForeground" Color="#7E3100" />
-    <SolidColorBrush x:Key="LabelTagLightOrangeBackground" Opacity="0.15" Color="#FC8800" />
-    <SolidColorBrush x:Key="LabelTagLightGreyForeground" Color="#2E3238" />
-    <SolidColorBrush x:Key="LabelTagLightGreyBackground" Opacity="0.15" Color="#6B7075" />
-    <SolidColorBrush x:Key="LabelTagLightWhiteForeground" Color="#1C1F23" />
-    <SolidColorBrush x:Key="LabelTagLightWhiteBackground" Opacity="0.15" Color="White" />
-    <SolidColorBrush x:Key="LabelTagLightWhiteBorderBrush" Color="#C6CACD" />
+    <StaticResource x:Key="LabelTagLightRedForeground" ResourceKey="SemiRed8" />
+    <SolidColorBrush x:Key="LabelTagLightRedBackground" Opacity="0.15" Color="{StaticResource SemiRed5Color}" />
+    <StaticResource x:Key="LabelTagLightPinkForeground" ResourceKey="SemiPink8" />
+    <SolidColorBrush x:Key="LabelTagLightPinkBackground" Opacity="0.15" Color="{StaticResource SemiPink5Color}" />
+    <StaticResource x:Key="LabelTagLightPurpleForeground" ResourceKey="SemiPurple8" />
+    <SolidColorBrush x:Key="LabelTagLightPurpleBackground" Opacity="0.15" Color="{StaticResource SemiPurple5Color}" />
+    <StaticResource x:Key="LabelTagLightVioletForeground" ResourceKey="SemiViolet8" />
+    <SolidColorBrush x:Key="LabelTagLightVioletBackground" Opacity="0.15" Color="{StaticResource SemiViolet5Color}" />
+    <StaticResource x:Key="LabelTagLightIndigoForeground" ResourceKey="SemiIndigo8" />
+    <SolidColorBrush x:Key="LabelTagLightIndigoBackground" Opacity="0.15" Color="{StaticResource SemiIndigo5Color}" />
+    <StaticResource x:Key="LabelTagLightBlueForeground" ResourceKey="SemiBlue8" />
+    <SolidColorBrush x:Key="LabelTagLightBlueBackground" Opacity="0.15" Color="{StaticResource SemiBlue5Color}" />
+    <StaticResource x:Key="LabelTagLightLightBlueForeground" ResourceKey="SemiLightBlue8" />
+    <SolidColorBrush x:Key="LabelTagLightLightBlueBackground" Opacity="0.15" Color="{StaticResource SemiLightBlue5Color}" />
+    <StaticResource x:Key="LabelTagLightCyanForeground" ResourceKey="SemiCyan8" />
+    <SolidColorBrush x:Key="LabelTagLightCyanBackground" Opacity="0.15" Color="{StaticResource SemiCyan5Color}" />
+    <StaticResource x:Key="LabelTagLightTealForeground" ResourceKey="SemiTeal8" />
+    <SolidColorBrush x:Key="LabelTagLightTealBackground" Opacity="0.15" Color="{StaticResource SemiTeal5Color}" />
+    <StaticResource x:Key="LabelTagLightGreenForeground" ResourceKey="SemiGreen8" />
+    <SolidColorBrush x:Key="LabelTagLightGreenBackground" Opacity="0.15" Color="{StaticResource SemiGreen5Color}" />
+    <StaticResource x:Key="LabelTagLightLightGreenForeground" ResourceKey="SemiLightGreen8" />
+    <SolidColorBrush x:Key="LabelTagLightLightGreenBackground" Opacity="0.15" Color="{StaticResource SemiLightGreen5Color}" />
+    <StaticResource x:Key="LabelTagLightLimeForeground" ResourceKey="SemiLime8" />
+    <SolidColorBrush x:Key="LabelTagLightLimeBackground" Opacity="0.15" Color="{StaticResource SemiLime5Color}" />
+    <StaticResource x:Key="LabelTagLightYellowForeground" ResourceKey="SemiYellow8" />
+    <SolidColorBrush x:Key="LabelTagLightYellowBackground" Opacity="0.15" Color="{StaticResource SemiYellow5Color}" />
+    <StaticResource x:Key="LabelTagLightAmberForeground" ResourceKey="SemiAmber8" />
+    <SolidColorBrush x:Key="LabelTagLightAmberBackground" Opacity="0.15" Color="{StaticResource SemiAmber5Color}" />
+    <StaticResource x:Key="LabelTagLightOrangeForeground" ResourceKey="SemiOrange8" />
+    <SolidColorBrush x:Key="LabelTagLightOrangeBackground" Opacity="0.15" Color="{StaticResource SemiOrange5Color}" />
+    <StaticResource x:Key="LabelTagLightGreyForeground" ResourceKey="SemiGrey8" />
+    <SolidColorBrush x:Key="LabelTagLightGreyBackground" Opacity="0.15" Color="{StaticResource SemiGrey5Color}" />
 
-    <SolidColorBrush x:Key="LabelTagGhostRedBorderBrush" Color="#FA664C" />
-    <SolidColorBrush x:Key="LabelTagGhostRedForeground" Color="#F93920" />
-    <SolidColorBrush x:Key="LabelTagGhostPinkBorderBrush" Color="#ED487B" />
-    <SolidColorBrush x:Key="LabelTagGhostPinkForeground" Color="#E91E63" />
-    <SolidColorBrush x:Key="LabelTagGhostPurpleBorderBrush" Color="#B449C2" />
-    <SolidColorBrush x:Key="LabelTagGhostPurpleForeground" Color="#9E28B3" />
-    <SolidColorBrush x:Key="LabelTagGhostVioletBorderBrush" Color="#885BD2" />
-    <SolidColorBrush x:Key="LabelTagGhostVioletForeground" Color="#6A3AC7" />
-    <SolidColorBrush x:Key="LabelTagGhostIndigoBorderBrush" Color="#5E6FC4" />
-    <SolidColorBrush x:Key="LabelTagGhostIndigoForeground" Color="#3F51B5" />
-    <SolidColorBrush x:Key="LabelTagGhostBlueBorderBrush" Color="#3295FB" />
-    <SolidColorBrush x:Key="LabelTagGhostBlueForeground" Color="#0064FA" />
-    <SolidColorBrush x:Key="LabelTagGhostLightBlueBorderBrush" Color="#30ACF1" />
-    <SolidColorBrush x:Key="LabelTagGhostLightBlueForeground" Color="#0095EE" />
-    <SolidColorBrush x:Key="LabelTagGhostCyanBorderBrush" Color="#2CB8C5" />
-    <SolidColorBrush x:Key="LabelTagGhostCyanForeground" Color="#05A4B6" />
-    <SolidColorBrush x:Key="LabelTagGhostTealBorderBrush" Color="#27C2B0" />
-    <SolidColorBrush x:Key="LabelTagGhostTealForeground" Color="#00B3A1" />
-    <SolidColorBrush x:Key="LabelTagGhostGreenBorderBrush" Color="#5AC262" />
-    <SolidColorBrush x:Key="LabelTagGhostGreenForeground" Color="#3BB346" />
-    <SolidColorBrush x:Key="LabelTagGhostLightGreenBorderBrush" Color="#93C55B" />
-    <SolidColorBrush x:Key="LabelTagGhostLightGreenForeground" Color="#7BB63C" />
-    <SolidColorBrush x:Key="LabelTagGhostLimeBorderBrush" Color="#A7DA2C" />
-    <SolidColorBrush x:Key="LabelTagGhostLimeForeground" Color="#9BD100" />
-    <SolidColorBrush x:Key="LabelTagGhostYellowBorderBrush" Color="#FBDA32" />
-    <SolidColorBrush x:Key="LabelTagGhostYellowForeground" Color="#FAC800" />
-    <SolidColorBrush x:Key="LabelTagGhostAmberBorderBrush" Color="#F3C341" />
-    <SolidColorBrush x:Key="LabelTagGhostAmberForeground" Color="#F0B114" />
-    <SolidColorBrush x:Key="LabelTagGhostOrangeBorderBrush" Color="#FDA633" />
-    <SolidColorBrush x:Key="LabelTagGhostOrangeForeground" Color="#FC8800" />
-    <SolidColorBrush x:Key="LabelTagGhostGreyBorderBrush" Color="#888D92" />
-    <SolidColorBrush x:Key="LabelTagGhostGreyForeground" Color="#6B7075" />
-    <SolidColorBrush x:Key="LabelTagGhostWhiteBorderBrush" Color="#C6CACD" />
-    <SolidColorBrush x:Key="LabelTagGhostWhiteForeground" Color="#1C1F23" />
+    <StaticResource x:Key="LabelTagLightWhiteForeground" ResourceKey="SemiColorText0" />
+    <StaticResource x:Key="LabelTagLightWhiteBackground" ResourceKey="SemiColorBackground4" />
+    <SolidColorBrush x:Key="LabelTagLightWhiteBorderBrush" Opacity="0.7" Color="{StaticResource SemiGrey2Color}" />
 
-    <SolidColorBrush x:Key="LabelTagSolidForeground" Color="White" />
-    <SolidColorBrush x:Key="LabelTagSolidRedBackground" Color="#F93920" />
-    <SolidColorBrush x:Key="LabelTagSolidPinkBackground" Color="#E91E63" />
-    <SolidColorBrush x:Key="LabelTagSolidPurpleBackground" Color="#9E28B3" />
-    <SolidColorBrush x:Key="LabelTagSolidVioletBackground" Color="#6A3AC7" />
-    <SolidColorBrush x:Key="LabelTagSolidIndigoBackground" Color="#3F51B5" />
-    <SolidColorBrush x:Key="LabelTagSolidBlueBackground" Color="#0064FA" />
-    <SolidColorBrush x:Key="LabelTagSolidLightBlueBackground" Color="#0095EE" />
-    <SolidColorBrush x:Key="LabelTagSolidCyanBackground" Color="#05A4B6" />
-    <SolidColorBrush x:Key="LabelTagSolidTealBackground" Color="#00B3A1" />
-    <SolidColorBrush x:Key="LabelTagSolidGreenBackground" Color="#3BB346" />
-    <SolidColorBrush x:Key="LabelTagSolidLightGreenBackground" Color="#7BB63C" />
-    <SolidColorBrush x:Key="LabelTagSolidLimeBackground" Color="#9BD100" />
-    <SolidColorBrush x:Key="LabelTagSolidYellowBackground" Color="#FAC800" />
-    <SolidColorBrush x:Key="LabelTagSolidAmberBackground" Color="#F0B114" />
-    <SolidColorBrush x:Key="LabelTagSolidOrangeBackground" Color="#FC8800" />
-    <SolidColorBrush x:Key="LabelTagSolidGreyBackground" Color="#6B7075" />
 
-    <SolidColorBrush x:Key="LabelTagSolidWhiteBackground" Color="White" />
-    <SolidColorBrush x:Key="LabelTagSolidWhiteBorderBrush" Color="#C6CACD" />
-    <SolidColorBrush x:Key="LabelTagSolidWhiteForeground" Color="#1C1F23" />
+    <StaticResource x:Key="LabelTagGhostRedBorderBrush" ResourceKey="SemiRed4" />
+    <StaticResource x:Key="LabelTagGhostRedForeground" ResourceKey="SemiRed5" />
+    <StaticResource x:Key="LabelTagGhostPinkBorderBrush" ResourceKey="SemiPink4" />
+    <StaticResource x:Key="LabelTagGhostPinkForeground" ResourceKey="SemiPink5" />
+    <StaticResource x:Key="LabelTagGhostPurpleBorderBrush" ResourceKey="SemiPurple4" />
+    <StaticResource x:Key="LabelTagGhostPurpleForeground" ResourceKey="SemiPurple5" />
+    <StaticResource x:Key="LabelTagGhostVioletBorderBrush" ResourceKey="SemiViolet4" />
+    <StaticResource x:Key="LabelTagGhostVioletForeground" ResourceKey="SemiViolet5" />
+    <StaticResource x:Key="LabelTagGhostIndigoBorderBrush" ResourceKey="SemiIndigo4" />
+    <StaticResource x:Key="LabelTagGhostIndigoForeground" ResourceKey="SemiIndigo5" />
+    <StaticResource x:Key="LabelTagGhostBlueBorderBrush" ResourceKey="SemiBlue4" />
+    <StaticResource x:Key="LabelTagGhostBlueForeground" ResourceKey="SemiBlue5" />
+    <StaticResource x:Key="LabelTagGhostLightBlueBorderBrush" ResourceKey="SemiLightBlue4" />
+    <StaticResource x:Key="LabelTagGhostLightBlueForeground" ResourceKey="SemiLightBlue5" />
+    <StaticResource x:Key="LabelTagGhostCyanBorderBrush" ResourceKey="SemiCyan4" />
+    <StaticResource x:Key="LabelTagGhostCyanForeground" ResourceKey="SemiCyan5" />
+    <StaticResource x:Key="LabelTagGhostTealBorderBrush" ResourceKey="SemiTeal4" />
+    <StaticResource x:Key="LabelTagGhostTealForeground" ResourceKey="SemiTeal5" />
+    <StaticResource x:Key="LabelTagGhostGreenBorderBrush" ResourceKey="SemiGreen4" />
+    <StaticResource x:Key="LabelTagGhostGreenForeground" ResourceKey="SemiGreen5" />
+    <StaticResource x:Key="LabelTagGhostLightGreenBorderBrush" ResourceKey="SemiLightGreen4" />
+    <StaticResource x:Key="LabelTagGhostLightGreenForeground" ResourceKey="SemiLightGreen5" />
+    <StaticResource x:Key="LabelTagGhostLimeBorderBrush" ResourceKey="SemiLime4" />
+    <StaticResource x:Key="LabelTagGhostLimeForeground" ResourceKey="SemiLime5" />
+    <StaticResource x:Key="LabelTagGhostYellowBorderBrush" ResourceKey="SemiYellow4" />
+    <StaticResource x:Key="LabelTagGhostYellowForeground" ResourceKey="SemiYellow5" />
+    <StaticResource x:Key="LabelTagGhostAmberBorderBrush" ResourceKey="SemiAmber4" />
+    <StaticResource x:Key="LabelTagGhostAmberForeground" ResourceKey="SemiAmber5" />
+    <StaticResource x:Key="LabelTagGhostOrangeBorderBrush" ResourceKey="SemiOrange4" />
+    <StaticResource x:Key="LabelTagGhostOrangeForeground" ResourceKey="SemiOrange5" />
+    <StaticResource x:Key="LabelTagGhostGreyBorderBrush" ResourceKey="SemiGrey4" />
+    <StaticResource x:Key="LabelTagGhostGreyForeground" ResourceKey="SemiGrey5" />
+
+    <StaticResource x:Key="LabelTagGhostWhiteForeground" ResourceKey="SemiColorText0" />
+    <StaticResource x:Key="LabelTagGhostWhiteBackground" ResourceKey="SemiColorBackground4" />
+    <SolidColorBrush x:Key="LabelTagGhostWhiteBorderBrush" Opacity="0.7" Color="{StaticResource SemiGrey2Color}" />
+
+
+    <StaticResource x:Key="LabelTagSolidForeground" ResourceKey="SemiWhite" />
+    <StaticResource x:Key="LabelTagSolidRedBackground" ResourceKey="SemiRed5" />
+    <StaticResource x:Key="LabelTagSolidPinkBackground" ResourceKey="SemiPink5" />
+    <StaticResource x:Key="LabelTagSolidPurpleBackground" ResourceKey="SemiPurple5" />
+    <StaticResource x:Key="LabelTagSolidVioletBackground" ResourceKey="SemiViolet5" />
+    <StaticResource x:Key="LabelTagSolidIndigoBackground" ResourceKey="SemiIndigo5" />
+    <StaticResource x:Key="LabelTagSolidBlueBackground" ResourceKey="SemiBlue5" />
+    <StaticResource x:Key="LabelTagSolidLightBlueBackground" ResourceKey="SemiLightBlue5" />
+    <StaticResource x:Key="LabelTagSolidCyanBackground" ResourceKey="SemiCyan5" />
+    <StaticResource x:Key="LabelTagSolidTealBackground" ResourceKey="SemiTeal5" />
+    <StaticResource x:Key="LabelTagSolidGreenBackground" ResourceKey="SemiGreen5" />
+    <StaticResource x:Key="LabelTagSolidLightGreenBackground" ResourceKey="SemiLightGreen5" />
+    <StaticResource x:Key="LabelTagSolidLimeBackground" ResourceKey="SemiLime5" />
+    <StaticResource x:Key="LabelTagSolidYellowBackground" ResourceKey="SemiYellow5" />
+    <StaticResource x:Key="LabelTagSolidAmberBackground" ResourceKey="SemiAmber5" />
+    <StaticResource x:Key="LabelTagSolidOrangeBackground" ResourceKey="SemiOrange5" />
+    <StaticResource x:Key="LabelTagSolidGreyBackground" ResourceKey="SemiGrey5" />
+
+    <StaticResource x:Key="LabelTagSolidWhiteForeground" ResourceKey="SemiColorText0" />
+    <StaticResource x:Key="LabelTagSolidWhiteBackground" ResourceKey="SemiColorBackground4" />
+    <SolidColorBrush x:Key="LabelTagSolidWhiteBorderBrush" Opacity="0.7" Color="{StaticResource SemiGrey2Color}" />
 </ResourceDictionary>

--- a/src/Semi.Avalonia/Tokens/Palette/Light.axaml
+++ b/src/Semi.Avalonia/Tokens/Palette/Light.axaml
@@ -57,7 +57,7 @@
     <Color x:Key="SemiBlue2Color">#98CDFD</Color>
     <Color x:Key="SemiBlue3Color">#65B2FC</Color>
     <Color x:Key="SemiBlue4Color">#3295FB</Color>
-    <Color x:Key="SemiBlue5Color">#0077FA</Color>
+    <Color x:Key="SemiBlue5Color">#0064FA</Color>
     <Color x:Key="SemiBlue6Color">#0062D6</Color>
     <Color x:Key="SemiBlue7Color">#004FB3</Color>
     <Color x:Key="SemiBlue8Color">#003D8F</Color>

--- a/src/Semi.Avalonia/Tokens/Variables.axaml
+++ b/src/Semi.Avalonia/Tokens/Variables.axaml
@@ -20,6 +20,10 @@
     <Thickness x:Key="SemiBorderThicknessControl">1</Thickness> <!-- 描边宽度 - 默认状态 -->
     <Thickness x:Key="SemiBorderThicknessControlFocus">1</Thickness> <!-- 描边宽度 - focus 状态 -->
     <CornerRadius x:Key="SemiBorderRadiusExtraSmall">3</CornerRadius> <!-- 圆角 - 超小 -->
+    <x:Double x:Key="SemiBorderRadiusSpacingSmall">3</x:Double> <!-- 半径 - 小 -->
+    <x:Double x:Key="SemiBorderRadiusSpacingMedium">6</x:Double> <!-- 半径 - 中 -->
+    <x:Double x:Key="SemiBorderRadiusSpacingLarge">12</x:Double> <!-- 半径 - 大 -->
+    <x:Double x:Key="SemiBorderRadiusSpacingFull">9999</x:Double> <!-- 半径 - 全圆 -->
     <CornerRadius x:Key="SemiBorderRadiusSmall">3</CornerRadius> <!-- 圆角 - 小 -->
     <CornerRadius x:Key="SemiBorderRadiusMedium">6</CornerRadius> <!-- 圆角 - 中 -->
     <CornerRadius x:Key="SemiBorderRadiusLarge">12</CornerRadius> <!-- 圆角 - 大 -->


### PR DESCRIPTION
This pull request involves multiple changes to the `Label.axaml` files in the `Semi.Avalonia` project, focusing on the removal of redundant styles and the replacement of `SolidColorBrush` resources with `StaticResource` references for better maintainability and consistency.

### Removal of Redundant Styles:
* Removed the `^.White` style from the `Label.axaml` file as it was redundant and no longer needed. [[1]](diffhunk://#diff-fdcefa1b0831abaa1deed3cdf204b7eb1028328cf9183d1ce15ce35a270cb7cfL269-L273) [[2]](diffhunk://#diff-fdcefa1b0831abaa1deed3cdf204b7eb1028328cf9183d1ce15ce35a270cb7cfL343-L347)

### Replacement of `SolidColorBrush` with `StaticResource`:
* Replaced multiple `SolidColorBrush` definitions with `StaticResource` references in the `Dark/Label.axaml` file to improve resource management and ensure consistency across the application.

### Codebase Simplification:
* Simplified the `Label.axaml` file by closing the `Style` tag for the `^.Grey` selector and removing the redundant closing tag.

These changes aim to streamline the styling definitions and enhance the maintainability of the codebase.