### PR TITLE
fix disabled fill color in RadioButton & add default FontWeight to TagLabel

### DIFF
--- a/src/Semi.Avalonia/Controls/Label.axaml
+++ b/src/Semi.Avalonia/Controls/Label.axaml
@@ -173,6 +173,7 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Padding" Value="{DynamicResource LabelTagSmallPadding}" />
         <Setter Property="FontSize" Value="{DynamicResource LabelTagFontSize}" />
+        <Setter Property="FontWeight" Value="{DynamicResource LabelTagFontWeight}" />
         <Setter Property="Template">
             <ControlTemplate TargetType="Label">
                 <ContentPresenter

--- a/src/Semi.Avalonia/Themes/Dark/RadioButton.axaml
+++ b/src/Semi.Avalonia/Themes/Dark/RadioButton.axaml
@@ -4,7 +4,7 @@
     <SolidColorBrush x:Key="RadioButtonUncheckIconDefaultBackground" Color="Transparent" />
     <StaticResource x:Key="RadioButtonUncheckIconPointeroverBackground" ResourceKey="SemiColorFill0" />
     <StaticResource x:Key="RadioButtonUncheckIconPressedBackground" ResourceKey="SemiColorFill1" />
-    <StaticResource x:Key="RadioButtonUncheckIconDisabledBackground" ResourceKey="SemiColorFill0" />
+    <StaticResource x:Key="RadioButtonUncheckIconDisabledBackground" ResourceKey="SemiColorDisabledFill" />
     <StaticResource x:Key="RadioButtonUncheckIconDefaultBorderBrush" ResourceKey="SemiColorText3" />
     <StaticResource x:Key="RadioButtonUncheckIconPointeroverBorderBrush" ResourceKey="SemiColorPrimaryPointerover" />
     <StaticResource x:Key="RadioButtonUncheckIconPressedBorderBrush" ResourceKey="SemiColorPrimaryActive" />

--- a/src/Semi.Avalonia/Themes/Light/RadioButton.axaml
+++ b/src/Semi.Avalonia/Themes/Light/RadioButton.axaml
@@ -4,7 +4,7 @@
     <SolidColorBrush x:Key="RadioButtonUncheckIconDefaultBackground" Color="Transparent" />
     <StaticResource x:Key="RadioButtonUncheckIconPointeroverBackground" ResourceKey="SemiColorFill0" />
     <StaticResource x:Key="RadioButtonUncheckIconPressedBackground" ResourceKey="SemiColorFill1" />
-    <StaticResource x:Key="RadioButtonUncheckIconDisabledBackground" ResourceKey="SemiColorFill0" />
+    <StaticResource x:Key="RadioButtonUncheckIconDisabledBackground" ResourceKey="SemiColorDisabledFill" />
     <StaticResource x:Key="RadioButtonUncheckIconDefaultBorderBrush" ResourceKey="SemiColorText3" />
     <StaticResource x:Key="RadioButtonUncheckIconPointeroverBorderBrush" ResourceKey="SemiColorPrimaryPointerover" />
     <StaticResource x:Key="RadioButtonUncheckIconPressedBorderBrush" ResourceKey="SemiColorPrimaryActive" />

--- a/src/Semi.Avalonia/Themes/Shared/Label.axaml
+++ b/src/Semi.Avalonia/Themes/Shared/Label.axaml
@@ -5,6 +5,7 @@
     <x:Double x:Key="LabelTagSmallHeight">20</x:Double>
     <x:Double x:Key="LabelTagLargeHeight">24</x:Double>
     <StaticResource x:Key="LabelTagFontSize" ResourceKey="SemiFontSizeSmall" />
+    <StaticResource x:Key="LabelTagFontWeight" ResourceKey="SemiFontWeightRegular" />
     <StaticResource x:Key="LabelTagSquareCornerRadius" ResourceKey="SemiBorderRadiusSmall" />
     <StaticResource x:Key="LabelTagCircleCornerRadius" ResourceKey="SemiBorderRadiusFull" />
 </ResourceDictionary>


### PR DESCRIPTION
This pull request includes several changes to the `Semi.Avalonia` project, focusing on enhancing the styling and consistency of UI elements. The most important changes include adding a new font weight property to labels and updating the disabled background color for radio buttons in both dark and light themes.

Styling updates:

* [`src/Semi.Avalonia/Controls/Label.axaml`](diffhunk://#diff-fdcefa1b0831abaa1deed3cdf204b7eb1028328cf9183d1ce15ce35a270cb7cfR176): Added a new `FontWeight` property to the label control to allow dynamic font weight adjustments.
* [`src/Semi.Avalonia/Themes/Shared/Label.axaml`](diffhunk://#diff-9de21d72dec838163ed7b56f3e601092bfacaff0916ed50d991ac43e33298a33R8): Introduced a new `LabelTagFontWeight` resource key to define the default font weight for labels.

Theme consistency improvements:

* [`src/Semi.Avalonia/Themes/Dark/RadioButton.axaml`](diffhunk://#diff-9a55938642d4f4e1eae219d7aef236fc0a730e1cf3224285534385528cdaa4a2L7-R7): Updated the `RadioButtonUncheckIconDisabledBackground` to use `SemiColorDisabledFill` for better visual consistency in the dark theme.
* [`src/Semi.Avalonia/Themes/Light/RadioButton.axaml`](diffhunk://#diff-9a55938642d4f4e1eae219d7aef236fc0a730e1cf3224285534385528cdaa4a2L7-R7): Updated the `RadioButtonUncheckIconDisabledBackground` to use `SemiColorDisabledFill` for better visual consistency in the light theme.