### PR TITLE
optimize Theme style references for Separate Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ dotnet add package Semi.Avalonia.TreeDataGrid
 
 ```xaml
 <Application.Styles>
-    <StyleInclude Source="avares://Semi.Avalonia.ColorPicker/Index.axaml" />
-    <StyleInclude Source="avares://Semi.Avalonia.DataGrid/Index.axaml" />
-    <StyleInclude Source="avares://Semi.Avalonia.TreeDataGrid/Index.axaml" />
+    <semi:ColorPickerSemiTheme />
+    <semi:DataGridSemiTheme />
+    <semi:TreeDataGridSemiTheme />
 </Application.Styles>
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -48,9 +48,9 @@ dotnet add package Semi.Avalonia.TreeDataGrid
 
 ```xaml
 <Application.Styles>
-    <StyleInclude Source="avares://Semi.Avalonia.ColorPicker/Index.axaml" />
-    <StyleInclude Source="avares://Semi.Avalonia.DataGrid/Index.axaml" />
-    <StyleInclude Source="avares://Semi.Avalonia.TreeDataGrid/Index.axaml" />
+    <semi:ColorPickerSemiTheme />
+    <semi:DataGridSemiTheme />
+    <semi:TreeDataGridSemiTheme />
 </Application.Styles>
 ```
 

--- a/demo/Semi.Avalonia.Demo/App.axaml
+++ b/demo/Semi.Avalonia.Demo/App.axaml
@@ -11,9 +11,9 @@
         <!-- <StyleInclude Source="avares://Semi.Avalonia/Index.axaml" /> -->
         <semi:SemiTheme Locale="zh-CN" />
         <semi:SemiPopupAnimations />
-        <StyleInclude Source="avares://Semi.Avalonia.DataGrid/Index.axaml" />
-        <StyleInclude Source="avares://Semi.Avalonia.ColorPicker/Index.axaml" />
-        <StyleInclude Source="avares://Semi.Avalonia.TreeDataGrid/Index.axaml" />
+        <semi:ColorPickerSemiTheme />
+        <semi:DataGridSemiTheme />
+        <semi:TreeDataGridSemiTheme />
     </Application.Styles>
     <Application.Resources>
         <ResourceDictionary>

--- a/demo/Semi.Avalonia.Demo/App.axaml
+++ b/demo/Semi.Avalonia.Demo/App.axaml
@@ -7,8 +7,6 @@
     xmlns:semi="https://irihi.tech/semi"
     xmlns:viewModels="clr-namespace:Semi.Avalonia.Demo.ViewModels">
     <Application.Styles>
-        <!-- You can still reference in old way.  -->
-        <!-- <StyleInclude Source="avares://Semi.Avalonia/Index.axaml" /> -->
         <semi:SemiTheme Locale="zh-CN" />
         <semi:SemiPopupAnimations />
         <semi:ColorPickerSemiTheme />
@@ -18,8 +16,7 @@
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceInclude
-                    Source="Themes/_index.axaml" />
+                <ResourceInclude Source="Themes/_index.axaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/demo/Semi.Avalonia.Demo/Pages/Overview.axaml.cs
+++ b/demo/Semi.Avalonia.Demo/Pages/Overview.axaml.cs
@@ -14,8 +14,6 @@ public partial class Overview : UserControl
     public string MainStyle { get; set; } =
         """
         <Application.Styles>
-        <!-- You can still reference in old way.  -->
-        <!-- <StyleInclude Source="avares://Semi.Avalonia/Index.axaml" /> -->
             <semi:SemiTheme Locale="zh-CN" />
         </Application.Styles>
         """;
@@ -25,7 +23,7 @@ public partial class Overview : UserControl
     public string ColorPickerStyle { get; set; } =
         """
         <Application.Styles>
-            <StyleInclude Source="avares://Semi.Avalonia.ColorPicker/Index.axaml" />
+            <semi:ColorPickerSemiTheme />
         </Application.Styles>
         """;
 
@@ -34,7 +32,7 @@ public partial class Overview : UserControl
     public string DataGridStyle { get; set; } =
         """
         <Application.Styles>
-            <StyleInclude Source="avares://Semi.Avalonia.DataGrid/Index.axaml" />
+            <semi:DataGridSemiTheme />
         </Application.Styles>
         """;
 
@@ -43,7 +41,7 @@ public partial class Overview : UserControl
     public string TreeDataGridStyle { get; set; } =
         """
         <Application.Styles>
-            <StyleInclude Source="avares://Semi.Avalonia.TreeDataGrid/Index.axaml" />
+            <semi:TreeDataGridSemiTheme />
         </Application.Styles>
         """;
 }

--- a/src/Semi.Avalonia.ColorPicker/ColorPickerSemiTheme.axaml
+++ b/src/Semi.Avalonia.ColorPicker/ColorPickerSemiTheme.axaml
@@ -1,0 +1,17 @@
+<Styles
+    x:Class="Semi.Avalonia.ColorPicker.ColorPickerSemiTheme"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Styles.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceInclude x:Key="Default" Source="Light.axaml" />
+                <ResourceInclude x:Key="Dark" Source="Dark.axaml" />
+            </ResourceDictionary.ThemeDictionaries>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source="Controls/_index.axaml" />
+                <ResourceInclude Source="Shared.axaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Styles.Resources>
+</Styles>

--- a/src/Semi.Avalonia.ColorPicker/ColorPickerSemiTheme.axaml.cs
+++ b/src/Semi.Avalonia.ColorPicker/ColorPickerSemiTheme.axaml.cs
@@ -1,0 +1,7 @@
+﻿using Avalonia.Styling;
+
+namespace Semi.Avalonia.ColorPicker;
+
+public class ColorPickerSemiTheme : Styles
+{
+}

--- a/src/Semi.Avalonia.DataGrid/AssemblyInfo.cs
+++ b/src/Semi.Avalonia.DataGrid/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using Avalonia.Metadata;
+
+[assembly: XmlnsDefinition("https://irihi.tech/semi", "Semi.Avalonia.DataGrid")]

--- a/src/Semi.Avalonia.DataGrid/DataGridSemiTheme.axaml
+++ b/src/Semi.Avalonia.DataGrid/DataGridSemiTheme.axaml
@@ -1,0 +1,17 @@
+<Styles
+    x:Class="Semi.Avalonia.DataGrid.DataGridSemiTheme"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Styles.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceInclude x:Key="Default" Source="Light.axaml" />
+                <ResourceInclude x:Key="Dark" Source="Dark.axaml" />
+            </ResourceDictionary.ThemeDictionaries>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source="DataGrid.axaml" />
+                <ResourceInclude Source="Shared.axaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Styles.Resources>
+</Styles>

--- a/src/Semi.Avalonia.DataGrid/DataGridSemiTheme.axaml.cs
+++ b/src/Semi.Avalonia.DataGrid/DataGridSemiTheme.axaml.cs
@@ -1,0 +1,7 @@
+﻿using Avalonia.Styling;
+
+namespace Semi.Avalonia.DataGrid;
+
+public class DataGridSemiTheme : Styles
+{
+}

--- a/src/Semi.Avalonia.TreeDataGrid/AssemblyInfo.cs
+++ b/src/Semi.Avalonia.TreeDataGrid/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using Avalonia.Metadata;
+
+[assembly: XmlnsDefinition("https://irihi.tech/semi", "Semi.Avalonia.TreeDataGrid")]

--- a/src/Semi.Avalonia.TreeDataGrid/TreeDataGridSemiTheme.axaml
+++ b/src/Semi.Avalonia.TreeDataGrid/TreeDataGridSemiTheme.axaml
@@ -1,0 +1,17 @@
+<Styles
+    x:Class="Semi.Avalonia.TreeDataGrid.TreeDataGridSemiTheme"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Styles.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceInclude x:Key="Default" Source="Light.axaml" />
+                <ResourceInclude x:Key="Dark" Source="Dark.axaml" />
+            </ResourceDictionary.ThemeDictionaries>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceInclude Source="TreeDataGrid.axaml" />
+                <ResourceInclude Source="Shared.axaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Styles.Resources>
+</Styles>

--- a/src/Semi.Avalonia.TreeDataGrid/TreeDataGridSemiTheme.axaml.cs
+++ b/src/Semi.Avalonia.TreeDataGrid/TreeDataGridSemiTheme.axaml.cs
@@ -1,0 +1,7 @@
+﻿using Avalonia.Styling;
+
+namespace Semi.Avalonia.TreeDataGrid;
+
+public class TreeDataGridSemiTheme : Styles
+{
+}


### PR DESCRIPTION
This pull request introduces a significant refactoring of how themes are defined and applied in the Semi.Avalonia library. It replaces the previous `StyleInclude` references with dedicated theme classes (`ColorPickerSemiTheme`, `DataGridSemiTheme`, and `TreeDataGridSemiTheme`) for better modularity, maintainability, and clarity. Additionally, new theme files and associated classes are added for these components.

### Refactoring of Theme References:

* Updated `README.md` and `README_CN.md` to replace `StyleInclude` references with the new theme classes (`semi:ColorPickerSemiTheme`, `semi:DataGridSemiTheme`, and `semi:TreeDataGridSemiTheme`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L51-R53) [[2]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7L51-R53)
* Refactored `App.axaml` in the demo application to use the new theme classes instead of `StyleInclude` references.
* Updated `Overview.axaml.cs` in the demo application to reflect the new theme class usage in the `MainStyle`, `ColorPickerStyle`, `DataGridStyle`, and `TreeDataGridStyle` properties. [[1]](diffhunk://#diff-d43008d5492a43c022bd2068b84a22711ef57c75740fcfb7afe62021e61d550fL17-L18) [[2]](diffhunk://#diff-d43008d5492a43c022bd2068b84a22711ef57c75740fcfb7afe62021e61d550fL28-R26) [[3]](diffhunk://#diff-d43008d5492a43c022bd2068b84a22711ef57c75740fcfb7afe62021e61d550fL37-R35) [[4]](diffhunk://#diff-d43008d5492a43c022bd2068b84a22711ef57c75740fcfb7afe62021e61d550fL46-R44)

### Addition of New Theme Classes and Files:

* Added `ColorPickerSemiTheme.axaml` and `ColorPickerSemiTheme.axaml.cs` to define the `ColorPickerSemiTheme` class and its associated styles. [[1]](diffhunk://#diff-89ce244ad5a6737fee018246a19d4862f17e80c48206693dea647ec8e539d667R1-R17) [[2]](diffhunk://#diff-93ba5fb8a0d6351d63933323cd7f208bec260375e98362c60bb1fb4231ca18d8R1-R7)
* Added `DataGridSemiTheme.axaml` and `DataGridSemiTheme.axaml.cs` to define the `DataGridSemiTheme` class and its associated styles. [[1]](diffhunk://#diff-2823971af6123e5ad0fccb376d9c52590e5378ee99d0c0301a033d75e007d902R1-R17) [[2]](diffhunk://#diff-a4d6f71fc317c4cf1156f73c8eee056d2038ceda2518432f9ebc28de59e35ba0R1-R7)
* Added `TreeDataGridSemiTheme.axaml` and `TreeDataGridSemiTheme.axaml.cs` to define the `TreeDataGridSemiTheme` class and its associated styles. [[1]](diffhunk://#diff-0ed9552a35d49223ab8daff7d94a358911a9108623a28c7b45471f63510323a9R1-R17) [[2]](diffhunk://#diff-4ab878a8b2de92f697ed26095d0b39142016f36d6a341ef28313935f5bc08e7fR1-R7)

### Namespace Enhancements:

* Added `XmlnsDefinition` attributes in `AssemblyInfo.cs` for `Semi.Avalonia.DataGrid` and `Semi.Avalonia.TreeDataGrid` to ensure proper namespace mapping for the new theme classes. [[1]](diffhunk://#diff-216853f24c4d70426a4b88e6c608d2e47a5e2c3e6250d3e8a0325ea6a4b4abeaR1-R3) [[2]](diffhunk://#diff-65693c43422f031684b05b30e8b6d15a984058e61cd8f8dce596513016c85a3bR1-R3)