### PR TITLE
Add opacity to CheckGlyph when :disabled

### DIFF
--- a/src/Semi.Avalonia/Controls/CheckBox.axaml
+++ b/src/Semi.Avalonia/Controls/CheckBox.axaml
@@ -33,6 +33,7 @@
                     CornerRadius="{TemplateBinding CornerRadius}">
                     <Grid ColumnDefinitions="Auto,*">
                         <Panel
+                            Name="PART_GlyphPanel"
                             Grid.Column="0"
                             TemplatedControl.IsTemplateFocusTarget="True"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
@@ -106,13 +107,9 @@
                 <Style Selector="^ /template/ Border#NormalRectangle">
                     <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckedDisabledBorderBrush}" />
                     <Setter Property="Background" Value="{DynamicResource CheckBoxCheckedDisabledBackground}" />
-                    <Setter Property="Opacity" Value="0.75" />
                 </Style>
                 <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
                     <Setter Property="Foreground" Value="{DynamicResource CheckBoxDisabledForeground}" />
-                </Style>
-                <Style Selector="^ /template/ PathIcon#CheckGlyph">
-                    <Setter Property="Foreground" Value="{DynamicResource CheckBoxGlyphDisabledFill}" />
                 </Style>
             </Style>
         </Style>
@@ -123,6 +120,12 @@
 
         <Style Selector="^:checked /template/ PathIcon#CheckGlyph">
             <Setter Property="Data" Value="{DynamicResource CheckBoxCheckGlyph}" />
+        </Style>
+
+        <Style Selector="^:disabled">
+            <Style Selector="^ /template/ Panel#PART_GlyphPanel">
+                <Setter Property="Opacity" Value="0.75" />
+            </Style>
         </Style>
     </ControlTheme>
 
@@ -138,7 +141,9 @@
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}"
                     CornerRadius="{TemplateBinding CornerRadius}">
-                    <Panel VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                    <Panel
+                        Name="PART_GlyphPanel"
+                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                         <Border
                             Name="NormalRectangle"
                             Width="{DynamicResource CheckBoxBoxWidth}"
@@ -183,6 +188,7 @@
                         VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                         ColumnDefinitions="Auto,*">
                         <Panel
+                            Name="PART_GlyphPanel"
                             Grid.Column="0"
                             VerticalAlignment="Top"
                             Margin="{DynamicResource CheckBoxBoxMargin}">
@@ -279,16 +285,12 @@
                 <Style Selector="^ /template/ Border#NormalRectangle">
                     <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckedDisabledBorderBrush}" />
                     <Setter Property="Background" Value="{DynamicResource CheckBoxCheckedDisabledBackground}" />
-                    <Setter Property="Opacity" Value="0.75" />
                 </Style>
                 <Style Selector="^ /template/ Border#RootBorder">
                     <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCardCheckedDisabledBorderBrush}" />
                 </Style>
                 <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
                     <Setter Property="Foreground" Value="{DynamicResource CheckBoxDisabledForeground}" />
-                </Style>
-                <Style Selector="^ /template/ PathIcon#CheckGlyph">
-                    <Setter Property="Foreground" Value="{DynamicResource CheckBoxGlyphDisabledFill}" />
                 </Style>
             </Style>
         </Style>
@@ -303,6 +305,12 @@
             </Style>
             <Style Selector="^ /template/ Border#RootBorder">
                 <Setter Property="Background" Value="{DynamicResource CheckBoxCardCheckedBackground}" />
+            </Style>
+        </Style>
+
+        <Style Selector="^:disabled">
+            <Style Selector="^ /template/ Panel#PART_GlyphPanel">
+                <Setter Property="Opacity" Value="0.75" />
             </Style>
         </Style>
     </ControlTheme>

--- a/src/Semi.Avalonia/Controls/ListBox.axaml
+++ b/src/Semi.Avalonia/Controls/ListBox.axaml
@@ -137,6 +137,7 @@
                     CornerRadius="{TemplateBinding CornerRadius}">
                     <Grid ColumnDefinitions="Auto,*">
                         <Panel
+                            Name="PART_GlyphPanel"
                             Grid.Column="0"
                             TemplatedControl.IsTemplateFocusTarget="True"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
@@ -224,11 +225,16 @@
                 <Style Selector="^ /template/ Ellipse#OuterEllipse">
                     <Setter Property="Stroke" Value="{DynamicResource RadioButtonCheckIconDisabledBorderBrush}" />
                     <Setter Property="Fill" Value="{DynamicResource RadioButtonCheckIconDisabledBackground}" />
-                    <Setter Property="Opacity" Value="0.75" />
                 </Style>
                 <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
                     <Setter Property="Foreground" Value="{DynamicResource RadioButtonDisabledForeground}" />
                 </Style>
+            </Style>
+        </Style>
+
+        <Style Selector="^:disabled">
+            <Style Selector="^ /template/ Panel#PART_GlyphPanel">
+                <Setter Property="Opacity" Value="0.75" />
             </Style>
         </Style>
     </ControlTheme>
@@ -321,6 +327,7 @@
                         VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                         ColumnDefinitions="Auto,*">
                         <Panel
+                            Name="PART_GlyphPanel"
                             Grid.Column="0"
                             VerticalAlignment="Top"
                             Margin="{DynamicResource RadioButtonIconMargin}">
@@ -431,7 +438,6 @@
                 <Style Selector="^ /template/ Ellipse#OuterEllipse">
                     <Setter Property="Stroke" Value="{DynamicResource RadioButtonCheckIconDisabledBorderBrush}" />
                     <Setter Property="Fill" Value="{DynamicResource RadioButtonCheckIconDisabledBackground}" />
-                    <Setter Property="Opacity" Value="0.75" />
                 </Style>
                 <Style Selector="^ /template/ Border#RootBorder">
                     <Setter Property="BorderBrush" Value="{DynamicResource RadioButtonCheckIconDisabledBackground}" />
@@ -440,6 +446,12 @@
                 <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
                     <Setter Property="Foreground" Value="{DynamicResource RadioButtonDisabledForeground}" />
                 </Style>
+            </Style>
+        </Style>
+
+        <Style Selector="^:disabled">
+            <Style Selector="^ /template/ Panel#PART_GlyphPanel">
+                <Setter Property="Opacity" Value="0.75" />
             </Style>
         </Style>
     </ControlTheme>
@@ -539,6 +551,7 @@
                     CornerRadius="{TemplateBinding CornerRadius}">
                     <Grid ColumnDefinitions="Auto,*">
                         <Panel
+                            Name="PART_GlyphPanel"
                             Grid.Column="0"
                             TemplatedControl.IsTemplateFocusTarget="True"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
@@ -612,19 +625,21 @@
                 <Style Selector="^ /template/ Border#NormalRectangle">
                     <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckedDisabledBorderBrush}" />
                     <Setter Property="Background" Value="{DynamicResource CheckBoxCheckedDisabledBackground}" />
-                    <Setter Property="Opacity" Value="0.75" />
                 </Style>
                 <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
                     <Setter Property="Foreground" Value="{DynamicResource CheckBoxDisabledForeground}" />
-                </Style>
-                <Style Selector="^ /template/ PathIcon#CheckGlyph">
-                    <Setter Property="Foreground" Value="{DynamicResource CheckBoxGlyphDisabledFill}" />
                 </Style>
             </Style>
         </Style>
 
         <Style Selector="^:selected /template/ PathIcon#CheckGlyph">
             <Setter Property="Data" Value="{DynamicResource CheckBoxCheckGlyph}" />
+        </Style>
+
+        <Style Selector="^:disabled">
+            <Style Selector="^ /template/ Panel#PART_GlyphPanel">
+                <Setter Property="Opacity" Value="0.75" />
+            </Style>
         </Style>
     </ControlTheme>
 
@@ -657,6 +672,7 @@
                         VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                         ColumnDefinitions="Auto,*">
                         <Panel
+                            Name="PART_GlyphPanel"
                             Grid.Column="0"
                             VerticalAlignment="Top"
                             Margin="{DynamicResource CheckBoxBoxMargin}">
@@ -753,7 +769,6 @@
                 <Style Selector="^ /template/ Border#NormalRectangle">
                     <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCheckedDisabledBorderBrush}" />
                     <Setter Property="Background" Value="{DynamicResource CheckBoxCheckedDisabledBackground}" />
-                    <Setter Property="Opacity" Value="0.75" />
                 </Style>
                 <Style Selector="^ /template/ Border#RootBorder">
                     <Setter Property="BorderBrush" Value="{DynamicResource CheckBoxCardCheckedDisabledBorderBrush}" />
@@ -761,8 +776,11 @@
                 <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
                     <Setter Property="Foreground" Value="{DynamicResource CheckBoxDisabledForeground}" />
                 </Style>
-                <Style Selector="^ /template/ PathIcon#CheckGlyph">
-                    <Setter Property="Foreground" Value="{DynamicResource CheckBoxGlyphDisabledFill}" />
+            </Style>
+
+            <Style Selector="^:disabled">
+                <Style Selector="^ /template/ Panel#PART_GlyphPanel">
+                    <Setter Property="Opacity" Value="0.75" />
                 </Style>
             </Style>
         </Style>

--- a/src/Semi.Avalonia/Controls/RadioButton.axaml
+++ b/src/Semi.Avalonia/Controls/RadioButton.axaml
@@ -34,6 +34,7 @@
                     CornerRadius="{TemplateBinding CornerRadius}">
                     <Grid ColumnDefinitions="Auto,*">
                         <Panel
+                            Name="PART_GlyphPanel"
                             Grid.Column="0"
                             TemplatedControl.IsTemplateFocusTarget="True"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
@@ -45,7 +46,6 @@
                                 Stroke="{DynamicResource RadioButtonUncheckIconDefaultBorderBrush}"
                                 StrokeThickness="{DynamicResource RadioButtonUncheckIconDefaultThickness}"
                                 UseLayoutRounding="False" />
-
                             <Ellipse
                                 Name="CheckGlyph"
                                 Width="{DynamicResource RadioButtonGlyphRadius}"
@@ -121,11 +121,16 @@
                 <Style Selector="^ /template/ Ellipse#OuterEllipse">
                     <Setter Property="Stroke" Value="{DynamicResource RadioButtonCheckIconDisabledBorderBrush}" />
                     <Setter Property="Fill" Value="{DynamicResource RadioButtonCheckIconDisabledBackground}" />
-                    <Setter Property="Opacity" Value="0.75" />
                 </Style>
                 <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
                     <Setter Property="Foreground" Value="{DynamicResource RadioButtonDisabledForeground}" />
                 </Style>
+            </Style>
+        </Style>
+
+        <Style Selector="^:disabled">
+            <Style Selector="^ /template/ Panel#PART_GlyphPanel">
+                <Setter Property="Opacity" Value="0.75" />
             </Style>
         </Style>
     </ControlTheme>
@@ -213,6 +218,7 @@
                         VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                         ColumnDefinitions="Auto,*">
                         <Panel
+                            Name="PART_GlyphPanel"
                             Grid.Column="0"
                             VerticalAlignment="Top"
                             Margin="{DynamicResource RadioButtonIconMargin}">
@@ -323,7 +329,6 @@
                 <Style Selector="^ /template/ Ellipse#OuterEllipse">
                     <Setter Property="Stroke" Value="{DynamicResource RadioButtonCheckIconDisabledBorderBrush}" />
                     <Setter Property="Fill" Value="{DynamicResource RadioButtonCheckIconDisabledBackground}" />
-                    <Setter Property="Opacity" Value="0.75" />
                 </Style>
                 <Style Selector="^ /template/ Border#RootBorder">
                     <Setter Property="BorderBrush" Value="{DynamicResource RadioButtonCheckIconDisabledBackground}" />
@@ -332,6 +337,12 @@
                 <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
                     <Setter Property="Foreground" Value="{DynamicResource RadioButtonDisabledForeground}" />
                 </Style>
+            </Style>
+        </Style>
+
+        <Style Selector="^:disabled">
+            <Style Selector="^ /template/ Panel#PART_GlyphPanel">
+                <Setter Property="Opacity" Value="0.75" />
             </Style>
         </Style>
     </ControlTheme>

--- a/src/Semi.Avalonia/Themes/Dark/CheckBox.axaml
+++ b/src/Semi.Avalonia/Themes/Dark/CheckBox.axaml
@@ -2,7 +2,6 @@
     <StaticResource x:Key="CheckBoxForeground" ResourceKey="SemiColorText0" />
     <StaticResource x:Key="CheckBoxDisabledForeground" ResourceKey="SemiColorDisabledText" />
     <StaticResource x:Key="CheckBoxGlyphFill" ResourceKey="SemiColorWhite" />
-    <StaticResource x:Key="CheckBoxGlyphDisabledFill" ResourceKey="SemiColorWhite" />
     <SolidColorBrush x:Key="CheckBoxDefaultBackground" Color="Transparent" />
     <StaticResource x:Key="CheckBoxDefaultBorderBrush" ResourceKey="SemiColorText3" />
     <StaticResource x:Key="CheckBoxPointeroverBackground" ResourceKey="SemiColorFill0" />
@@ -26,4 +25,7 @@
     <StaticResource x:Key="CheckBoxCardPressedBackground" ResourceKey="SemiColorFill1" />
     <StaticResource x:Key="CheckBoxCardCheckedPointeroverBorderBrush" ResourceKey="SemiColorPrimaryPointerover" />
     <StaticResource x:Key="CheckBoxCardCheckedPressedBorderBrush" ResourceKey="SemiColorPrimaryActive" />
+
+    <!-- Obsolete -->
+    <StaticResource x:Key="CheckBoxGlyphDisabledFill" ResourceKey="SemiColorWhite" />
 </ResourceDictionary>

--- a/src/Semi.Avalonia/Themes/HighContrast/CheckBox.axaml
+++ b/src/Semi.Avalonia/Themes/HighContrast/CheckBox.axaml
@@ -2,7 +2,6 @@
     <StaticResource x:Key="CheckBoxForeground" ResourceKey="SemiColorWindowText" />
     <StaticResource x:Key="CheckBoxDisabledForeground" ResourceKey="SemiColorGrayText" />
     <StaticResource x:Key="CheckBoxGlyphFill" ResourceKey="SemiColorHighlightText" />
-    <StaticResource x:Key="CheckBoxGlyphDisabledFill" ResourceKey="SemiColorHighlightText" />
     <StaticResource x:Key="CheckBoxDefaultBackground" ResourceKey="SemiColorWindow" />
     <StaticResource x:Key="CheckBoxDefaultBorderBrush" ResourceKey="SemiColorButtonText" />
     <StaticResource x:Key="CheckBoxPointeroverBackground" ResourceKey="SemiColorHighlightText" />
@@ -26,4 +25,7 @@
     <StaticResource x:Key="CheckBoxCardPressedBackground" ResourceKey="SemiColorWindow" />
     <StaticResource x:Key="CheckBoxCardCheckedPointeroverBorderBrush" ResourceKey="SemiColorButtonText" />
     <StaticResource x:Key="CheckBoxCardCheckedPressedBorderBrush" ResourceKey="SemiColorHighlight" />
+
+    <!-- Obsolete -->
+    <StaticResource x:Key="CheckBoxGlyphDisabledFill" ResourceKey="SemiColorHighlightText" />
 </ResourceDictionary>

--- a/src/Semi.Avalonia/Themes/Light/CheckBox.axaml
+++ b/src/Semi.Avalonia/Themes/Light/CheckBox.axaml
@@ -2,7 +2,6 @@
     <StaticResource x:Key="CheckBoxForeground" ResourceKey="SemiColorText0" />
     <StaticResource x:Key="CheckBoxDisabledForeground" ResourceKey="SemiColorDisabledText" />
     <StaticResource x:Key="CheckBoxGlyphFill" ResourceKey="SemiColorWhite" />
-    <StaticResource x:Key="CheckBoxGlyphDisabledFill" ResourceKey="SemiColorWhite" />
     <SolidColorBrush x:Key="CheckBoxDefaultBackground" Color="Transparent" />
     <StaticResource x:Key="CheckBoxDefaultBorderBrush" ResourceKey="SemiColorText3" />
     <StaticResource x:Key="CheckBoxPointeroverBackground" ResourceKey="SemiColorFill0" />
@@ -26,4 +25,7 @@
     <StaticResource x:Key="CheckBoxCardPressedBackground" ResourceKey="SemiColorFill1" />
     <StaticResource x:Key="CheckBoxCardCheckedPointeroverBorderBrush" ResourceKey="SemiColorPrimaryPointerover" />
     <StaticResource x:Key="CheckBoxCardCheckedPressedBorderBrush" ResourceKey="SemiColorPrimaryActive" />
+
+    <!-- Obsolete -->
+    <StaticResource x:Key="CheckBoxGlyphDisabledFill" ResourceKey="SemiColorWhite" />
 </ResourceDictionary>


### PR DESCRIPTION
This pull request introduces several changes to enhance the styling and structure of `CheckBox`, `RadioButton`, and `ListBox` controls in the `Semi.Avalonia` library. The changes include the addition of a new `PART_GlyphPanel` element, updates to the handling of disabled states, and the removal of obsolete styles. These updates aim to improve code maintainability and visual consistency across controls.

### Structural Enhancements:
* Added a `Panel` named `PART_GlyphPanel` to the templates of `CheckBox`, `RadioButton`, and `ListBox` controls to better organize their visual elements. (`src/Semi.Avalonia/Controls/CheckBox.axaml`: [[1]](diffhunk://#diff-c1fdb2a313958babcbe1c5a9792db129f496dba7d6234f3a0dfaa27cfea77243R36) [[2]](diffhunk://#diff-c1fdb2a313958babcbe1c5a9792db129f496dba7d6234f3a0dfaa27cfea77243L141-R146) [[3]](diffhunk://#diff-c1fdb2a313958babcbe1c5a9792db129f496dba7d6234f3a0dfaa27cfea77243R191); `src/Semi.Avalonia/Controls/ListBox.axaml`: [[4]](diffhunk://#diff-60259150967e04c80fa3375a4139c3f3f4a0a0f27f01408f02f968109a8e7e05R140) [[5]](diffhunk://#diff-60259150967e04c80fa3375a4139c3f3f4a0a0f27f01408f02f968109a8e7e05R330) [[6]](diffhunk://#diff-60259150967e04c80fa3375a4139c3f3f4a0a0f27f01408f02f968109a8e7e05R675); `src/Semi.Avalonia/Controls/RadioButton.axaml`: [[7]](diffhunk://#diff-06b683fd08faed49f5ae1346e6ae0fc4826328ccec1bbc2b166865412e3a8832R37) [[8]](diffhunk://#diff-06b683fd08faed49f5ae1346e6ae0fc4826328ccec1bbc2b166865412e3a8832R221)

### Disabled State Improvements:
* Moved the `Opacity` property for disabled states to a new `Style` targeting `PART_GlyphPanel`, ensuring consistent visual behavior across controls. (`src/Semi.Avalonia/Controls/CheckBox.axaml`: [[1]](diffhunk://#diff-c1fdb2a313958babcbe1c5a9792db129f496dba7d6234f3a0dfaa27cfea77243R124-R129) [[2]](diffhunk://#diff-c1fdb2a313958babcbe1c5a9792db129f496dba7d6234f3a0dfaa27cfea77243R310-R315); `src/Semi.Avalonia/Controls/ListBox.axaml`: [[3]](diffhunk://#diff-60259150967e04c80fa3375a4139c3f3f4a0a0f27f01408f02f968109a8e7e05L227-R239) [[4]](diffhunk://#diff-60259150967e04c80fa3375a4139c3f3f4a0a0f27f01408f02f968109a8e7e05R451-R456); `src/Semi.Avalonia/Controls/RadioButton.axaml`: [[5]](diffhunk://#diff-06b683fd08faed49f5ae1346e6ae0fc4826328ccec1bbc2b166865412e3a8832L124-R135) [[6]](diffhunk://#diff-06b683fd08faed49f5ae1346e6ae0fc4826328ccec1bbc2b166865412e3a8832R342-R347)

### Obsolete Style Removal:
* Removed the `CheckBoxGlyphDisabledFill` style from the `Dark` and `HighContrast` themes as it is no longer used. Added comments marking it as obsolete to maintain backward compatibility. (`src/Semi.Avalonia/Themes/Dark/CheckBox.axaml`: [[1]](diffhunk://#diff-3b9be4f78d31d3f634dc3c78d86141b79cef3dde4f1dc4ce4b50c754c32cd0e2L5) [[2]](diffhunk://#diff-3b9be4f78d31d3f634dc3c78d86141b79cef3dde4f1dc4ce4b50c754c32cd0e2R28-R30); `src/Semi.Avalonia/Themes/HighContrast/CheckBox.axaml`: [[3]](diffhunk://#diff-ade59b4ab93079f0f882e52eea5de98d5110207e5713cce0cfa7deac0114ab4bL5) [[4]](diffhunk://#diff-ade59b4ab93079f0f882e52eea5de98d5110207e5713cce0cfa7deac0114ab4bR28-R30)

### Code Cleanup:
* Removed redundant styles for `PathIcon#CheckGlyph` and similar elements, simplifying the overall styling structure. (`src/Semi.Avalonia/Controls/CheckBox.axaml`: [[1]](diffhunk://#diff-c1fdb2a313958babcbe1c5a9792db129f496dba7d6234f3a0dfaa27cfea77243L109-L116) [[2]](diffhunk://#diff-c1fdb2a313958babcbe1c5a9792db129f496dba7d6234f3a0dfaa27cfea77243L282-L292); `src/Semi.Avalonia/Controls/ListBox.axaml`: [[3]](diffhunk://#diff-60259150967e04c80fa3375a4139c3f3f4a0a0f27f01408f02f968109a8e7e05L615-R643) [[4]](diffhunk://#diff-60259150967e04c80fa3375a4139c3f3f4a0a0f27f01408f02f968109a8e7e05L756-R783); `src/Semi.Avalonia/Controls/RadioButton.axaml`: [[5]](diffhunk://#diff-06b683fd08faed49f5ae1346e6ae0fc4826328ccec1bbc2b166865412e3a8832L326)

These changes collectively improve the maintainability and consistency of the control templates, while also preparing the codebase for future enhancements.