### PR TITLE
Set scrollbar opacity to 1.

### DIFF
--- a/src/Semi.Avalonia/Controls/ScrollViewer.axaml
+++ b/src/Semi.Avalonia/Controls/ScrollViewer.axaml
@@ -269,17 +269,6 @@
                 </Grid>
             </ControlTemplate>
         </Setter>
-        <Style Selector="^ /template/ ScrollBar">
-            <Setter Property="Opacity" Value="0" />
-        </Style>
-        <Style Selector="^:pointerover">
-            <Style Selector="^ /template/ ScrollBar#PART_HorizontalScrollBar">
-                <Setter Property="Opacity" Value="1" />
-            </Style>
-            <Style Selector="^ /template/ ScrollBar#PART_VerticalScrollBar">
-                <Setter Property="Opacity" Value="1" />
-            </Style>
-        </Style>
         <Style Selector="^.InsetContent /template/ ScrollContentPresenter#PART_ContentPresenter">
             <Setter Property="Grid.RowSpan" Value="1"/>
             <Setter Property="Grid.ColumnSpan" Value="1"/>


### PR DESCRIPTION
Originally, Semi.Avalonia took the design from web world to hide scrollbar when it is not interacted. 

After https://github.com/AvaloniaUI/Avalonia/pull/18420 , `ScrollViewer` is no longer in ":pointerover" pseudoclass when pressing `ScrollBar`, which leads to the blinking of scrollbar. 

There is no more easy way to achieve the same effect.  Considering this is not that important, especially after we implemented `AllowAutoHide`, `ScrollBar` visually doesn't take to much space now. we can simply remove it