### PR TITLE
fix BorderBrush in OutlineDropDownButton

### DIFF
--- a/src/Semi.Avalonia/Controls/DropDownButton.axaml
+++ b/src/Semi.Avalonia/Controls/DropDownButton.axaml
@@ -259,24 +259,15 @@
         TargetType="DropDownButton">
         <Style Selector="^ /template/ Border#PART_Background">
             <Setter Property="Background" Value="{DynamicResource ButtonOutlineBackground}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource ButtonOutlinePrimaryBorderBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource ButtonOutlineBorderBrush}" />
         </Style>
         <Style Selector="^:pointerover /template/ Border#PART_Background">
             <Setter Property="Background" Value="{DynamicResource ButtonOutlinePointeroverBackground}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource ButtonOutlinePrimaryBorderBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource ButtonOutlineBorderBrush}" />
         </Style>
         <Style Selector="^:pressed /template/ Border#PART_Background">
             <Setter Property="Background" Value="{DynamicResource ButtonOutlinePressedBackground}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource ButtonOutlinePrimaryBorderBrush}" />
-        </Style>
-        <Style Selector="^.Primary /template/ Border#PART_Background">
-            <Setter Property="BorderBrush" Value="{DynamicResource ButtonOutlinePrimaryBorderBrush}" />
-        </Style>
-        <Style Selector="^.Secondary /template/ Border#PART_Background">
-            <Setter Property="BorderBrush" Value="{DynamicResource ButtonOutlineSecondaryBorderBrush}" />
-        </Style>
-        <Style Selector="^.Tertiary /template/ Border#PART_Background">
-            <Setter Property="BorderBrush" Value="{DynamicResource ButtonOutlineTertiaryBorderBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource ButtonOutlineBorderBrush}" />
         </Style>
         <Style Selector="^.Success /template/ Border#PART_Background">
             <Setter Property="BorderBrush" Value="{DynamicResource ButtonOutlineSuccessBorderBrush}" />


### PR DESCRIPTION
This pull request simplifies the styling of the `DropDownButton` control in `src/Semi.Avalonia/Controls/DropDownButton.axaml`. The changes consolidate the use of border brush resources, removing specific styles for `Primary`, `Secondary`, and `Tertiary` selectors.

Styling simplifications:

* Replaced `ButtonOutlinePrimaryBorderBrush` with `ButtonOutlineBorderBrush` for the `BorderBrush` property across various selectors, such as `^ /template/ Border#PART_Background`, `^:pointerover /template/ Border#PART_Background`, and `^:pressed /template/ Border#PART_Background`.
* Removed styles for `^.Primary`, `^.Secondary`, and `^.Tertiary` selectors, which previously defined distinct `BorderBrush` values.