### PR TITLE
Add Ads for Packages base Semi.Avalonia

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,15 @@ Include Semi Design Styles in application:
 
 That's all.
 
-ColorPicker, DataGrid and TreeDataGrid are distributed in separated packages. Please install if you need.
+ColorPicker, DataGrid, TreeDataGrid, Dock, Tabalonia and AvaloniaEdit are distributed in separated packages. Please install if you need.
 
 ```bash
 dotnet add package Semi.Avalonia.ColorPicker
 dotnet add package Semi.Avalonia.DataGrid
 dotnet add package Semi.Avalonia.TreeDataGrid
+dotnet add package Semi.Avalonia.Dock
+dotnet add package Semi.Avalonia.Tabalonia
+dotnet add package Semi.Avalonia.AvaloniaEdit
 ```
 
 ```xaml
@@ -51,8 +54,13 @@ dotnet add package Semi.Avalonia.TreeDataGrid
     <semi:ColorPickerSemiTheme />
     <semi:DataGridSemiTheme />
     <semi:TreeDataGridSemiTheme />
+    <semi:DockSemiTheme />
+    <semi:TabaloniaSemiTheme />
+    <semi:AvaloniaEditSemiTheme />
 </Application.Styles>
 ```
+
+Notice: Dock, Tabalonia and AvaloniaEdit are delivered via nuget for free, but not open source. Please read the license and agree to continue use these packages. If you need source code, please contact us via email: [contact@irihi.tech](contact@irihi.tech)
 
 ## Demo
 
@@ -63,7 +71,7 @@ You can always download demo executable to play around with Semi Avalonia Themes
 
 We offer limited free community support for Semi Avalonia and Ursa. If you have any question or suggestion, feel free to raise issues and discussions via GitHub, and you are welcomed to join our group via FeiShu(Lark)
 
-![FeiShu](./docs/community-support.png) 
+![FeiShu](./docs/community-support.png)
 
 ## Version compatibility
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -38,7 +38,7 @@ dotnet add package Semi.Avalonia
 
 这样就可以了。
 
-ColorPicker、DataGrid 和 TreeDataGrid 的样式单独分发，如果需要请安装并引用。
+ColorPicker、DataGrid、TreeDataGrid、Dock、Tabalonia 和 AvaloniaEdit 的样式单独分发，如果需要请安装并引用。
 
 ```bash
 dotnet add package Semi.Avalonia.ColorPicker
@@ -53,6 +53,8 @@ dotnet add package Semi.Avalonia.TreeDataGrid
     <semi:TreeDataGridSemiTheme />
 </Application.Styles>
 ```
+
+注意：Dock、Tabalonia 和 AvaloniaEdit 是通过 NuGet 免费分发的，但不是开源的。请阅读许可协议并同意后继续使用这些包。如果您需要源代码，请通过电子邮件联系我们：[contact@irihi.tech](contact@irihi.tech)
 
 ## 示例
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -44,6 +44,9 @@ ColorPicker、DataGrid、TreeDataGrid、Dock、Tabalonia 和 AvaloniaEdit 的样
 dotnet add package Semi.Avalonia.ColorPicker
 dotnet add package Semi.Avalonia.DataGrid
 dotnet add package Semi.Avalonia.TreeDataGrid
+dotnet add package Semi.Avalonia.Dock
+dotnet add package Semi.Avalonia.Tabalonia
+dotnet add package Semi.Avalonia.AvaloniaEdit
 ```
 
 ```xaml
@@ -51,6 +54,9 @@ dotnet add package Semi.Avalonia.TreeDataGrid
     <semi:ColorPickerSemiTheme />
     <semi:DataGridSemiTheme />
     <semi:TreeDataGridSemiTheme />
+    <semi:DockSemiTheme />
+    <semi:TabaloniaSemiTheme />
+    <semi:AvaloniaEditSemiTheme />
 </Application.Styles>
 ```
 

--- a/demo/Semi.Avalonia.Demo/Pages/Overview.axaml
+++ b/demo/Semi.Avalonia.Demo/Pages/Overview.axaml
@@ -348,7 +348,7 @@
                     Classes="H5"
                     Text="Start to install"
                     Theme="{DynamicResource TitleTextBlock}" />
-                <TabControl Padding="8">
+                <TabControl Theme="{StaticResource LineTabControl}">
                     <TabItem Header="Main">
                         <StackPanel>
                             <TextBlock Text="Install via nuget: " />
@@ -405,6 +405,51 @@
                                 <SelectableTextBlock
                                     FontFamily="Consolas"
                                     Text="{Binding $parent[local:Overview].TreeDataGridStyle}"
+                                    TextWrapping="Wrap" />
+                            </Border>
+                        </StackPanel>
+                    </TabItem>
+                    <TabItem Header="Dock">
+                        <StackPanel>
+                            <TextBlock Text="Install via nuget: " />
+                            <Border Margin="0,16" Classes="CodeBlock">
+                                <SelectableTextBlock FontFamily="Consolas" Text="{Binding $parent[local:Overview].DockInstall}" />
+                            </Border>
+                            <TextBlock Text="Reference styles: " />
+                            <Border Margin="0,16" Classes="CodeBlock">
+                                <SelectableTextBlock
+                                    FontFamily="Consolas"
+                                    Text="{Binding $parent[local:Overview].DockStyle}"
+                                    TextWrapping="Wrap" />
+                            </Border>
+                        </StackPanel>
+                    </TabItem>
+                    <TabItem Header="Tabalonia">
+                        <StackPanel>
+                            <TextBlock Text="Install via nuget: " />
+                            <Border Margin="0,16" Classes="CodeBlock">
+                                <SelectableTextBlock FontFamily="Consolas" Text="{Binding $parent[local:Overview].TabaloniaInstall}" />
+                            </Border>
+                            <TextBlock Text="Reference styles: " />
+                            <Border Margin="0,16" Classes="CodeBlock">
+                                <SelectableTextBlock
+                                    FontFamily="Consolas"
+                                    Text="{Binding $parent[local:Overview].TabaloniaStyle}"
+                                    TextWrapping="Wrap" />
+                            </Border>
+                        </StackPanel>
+                    </TabItem>
+                    <TabItem Header="AvaloniaEdit">
+                        <StackPanel>
+                            <TextBlock Text="Install via nuget: " />
+                            <Border Margin="0,16" Classes="CodeBlock">
+                                <SelectableTextBlock FontFamily="Consolas" Text="{Binding $parent[local:Overview].AvaloniaEditInstall}" />
+                            </Border>
+                            <TextBlock Text="Reference styles: " />
+                            <Border Margin="0,16" Classes="CodeBlock">
+                                <SelectableTextBlock
+                                    FontFamily="Consolas"
+                                    Text="{Binding $parent[local:Overview].AvaloniaEditStyle}"
                                     TextWrapping="Wrap" />
                             </Border>
                         </StackPanel>

--- a/demo/Semi.Avalonia.Demo/Pages/Overview.axaml.cs
+++ b/demo/Semi.Avalonia.Demo/Pages/Overview.axaml.cs
@@ -44,4 +44,31 @@ public partial class Overview : UserControl
             <semi:TreeDataGridSemiTheme />
         </Application.Styles>
         """;
+
+    public string DockInstall { get; set; } = "dotnet add package Semi.Avalonia.Dock --version 11.3.0";
+
+    public string DockStyle { get; set; } =
+        """
+        <Application.Styles>
+            <semi:DockSemiTheme />
+        </Application.Styles>
+        """;
+
+    public string TabaloniaInstall { get; set; } = "dotnet add package Semi.Avalonia.Tabalonia --version 11.0.0-beta1";
+
+    public string TabaloniaStyle { get; set; } =
+        """
+        <Application.Styles>
+            <semi:TabaloniaSemiTheme />
+        </Application.Styles>
+        """;
+
+    public string AvaloniaEditInstall { get; set; } = "dotnet add package Semi.Avalonia.AvaloniaEdit --version 11.2.0";
+
+    public string AvaloniaEditStyle { get; set; } =
+        """
+        <Application.Styles>
+            <semi:AvaloniaEditSemiTheme />
+        </Application.Styles>
+        """;
 }


### PR DESCRIPTION
This pull request introduces support for three additional Semi Avalonia themes (`Dock`, `Tabalonia`, and `AvaloniaEdit`) and updates relevant documentation and demo files to reflect these changes. The most important changes include updates to the README files, modifications to the demo application, and the addition of new properties in the `Overview.axaml.cs` file.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R64): Added instructions for installing and referencing the `Dock`, `Tabalonia`, and `AvaloniaEdit` themes. Included a note about licensing for these packages.
* [`README_CN.md`](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7L41-R64): Updated the Chinese-language README with similar instructions and licensing details for the new themes.

### Demo Application Enhancements:

* [`demo/Semi.Avalonia.Demo/Pages/Overview.axaml`](diffhunk://#diff-89428a73c40574941078fa5d0b64e3ebdf994df35a6eeba404e905387566c557R412-R456): Added new `TabItem` sections for `Dock`, `Tabalonia`, and `AvaloniaEdit` themes, including installation commands and style references.
* [`demo/Semi.Avalonia.Demo/Pages/Overview.axaml`](diffhunk://#diff-89428a73c40574941078fa5d0b64e3ebdf994df35a6eeba404e905387566c557L351-R351): Updated the `TabControl` to use the `LineTabControl` theme.

### Code Updates:

* [`demo/Semi.Avalonia.Demo/Pages/Overview.axaml.cs`](diffhunk://#diff-d43008d5492a43c022bd2068b84a22711ef57c75740fcfb7afe62021e61d550fR47-R73): Added new properties (`DockInstall`, `DockStyle`, `TabaloniaInstall`, `TabaloniaStyle`, `AvaloniaEditInstall`, `AvaloniaEditStyle`) to support the demo application's updates.