### PR TITLE
Fix binding in calendar date picker.

### DIFF
--- a/src/Semi.Avalonia/Controls/CalendarDatePicker.axaml
+++ b/src/Semi.Avalonia/Controls/CalendarDatePicker.axaml
@@ -111,7 +111,7 @@
                                         DisplayDateStart="{TemplateBinding DisplayDateStart}"
                                         FirstDayOfWeek="{TemplateBinding FirstDayOfWeek}"
                                         IsTodayHighlighted="{TemplateBinding IsTodayHighlighted}"
-                                        SelectedDate="{TemplateBinding SelectedDate, Mode=TwoWay}" />
+                                        SelectedDate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedDate, Mode=TwoWay}" />
                                 </Border>
                             </Popup>
                         </Grid>


### PR DESCRIPTION
This PR fix the binding of calendardatepicker. 
Before PR: when user clear the selected date, calendar still has a date highlighted. 
After PR, when user clear the selected date, calendar is also cleared. 