### PR TITLE
Turn on CompileBindings in DataValidationErrors and SplitView XAML

### DIFF
--- a/src/Semi.Avalonia/Controls/DataValidationErrors.axaml
+++ b/src/Semi.Avalonia/Controls/DataValidationErrors.axaml
@@ -1,7 +1,8 @@
 <ResourceDictionary
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:collections="clr-namespace:System.Collections;assembly=netstandard">
+    xmlns:collections="clr-namespace:System.Collections;assembly=netstandard"
+    x:CompileBindings="True">
     <ControlTheme x:Key="{x:Type DataValidationErrors}" TargetType="DataValidationErrors">
         <Setter Property="Template">
             <ControlTemplate TargetType="DataValidationErrors">

--- a/src/Semi.Avalonia/Controls/SplitView.axaml
+++ b/src/Semi.Avalonia/Controls/SplitView.axaml
@@ -1,4 +1,7 @@
-<ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<ResourceDictionary 
+    xmlns="https://github.com/avaloniaui" 
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    x:CompileBindings="True">
     <ControlTheme x:Key="{x:Type SplitView}" TargetType="SplitView">
         <Setter Property="OpenPaneLength" Value="{DynamicResource SplitViewOpenPaneThemeLength}" />
         <Setter Property="CompactPaneLength" Value="{DynamicResource SplitViewCompactPaneThemeLength}" />


### PR DESCRIPTION
avoid the compile warning:
> ILC : Trim analysis warning IL2026: CompiledAvaloniaXaml.!AvaloniaResources.XamlClosure_41.Build_1(IServiceProvider): Using member 'Avalonia.Markup.Xaml.MarkupExtensions.ReflectionBindingExtension.ReflectionBindingExtension()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. BindingExpression and ReflectionBinding heavily use reflection. Consider using CompiledBindings instead.

@FernandoWF could you please help to review it? I've created a branch called [sandbox](https://github.com/irihitech/Semi.Avalonia/tree/issue/sandbox).