### PR TITLE
fix: fix controls under TextBox inheriting Ibeam cursor

### DIFF
--- a/src/Semi.Avalonia/Controls/TextBox.axaml
+++ b/src/Semi.Avalonia/Controls/TextBox.axaml
@@ -29,7 +29,6 @@
         <Setter Property="BorderThickness" Value="{DynamicResource TextBoxBorderThickness}" />
         <Setter Property="BackgroundSizing" Value="OuterBorderEdge" />
         <Setter Property="CornerRadius" Value="{DynamicResource TextBoxDefaultCornerRadius}" />
-        <Setter Property="Cursor" Value="Ibeam" />
         <Setter Property="CaretBrush" Value="{DynamicResource TextBoxTextCaretBrush}" />
         <Setter Property="Padding" Value="{DynamicResource TextBoxContentPadding}" />
         <Setter Property="MinHeight" Value="{DynamicResource TextBoxDefaultHeight}" />
@@ -97,6 +96,11 @@
                                         TextAlignment="{TemplateBinding TextAlignment}"
                                         TextWrapping="{TemplateBinding TextWrapping}" />
                                 </Panel>
+                                <ScrollViewer.Styles>
+                                    <Style Selector="ScrollContentPresenter#PART_ContentPresenter">
+                                        <Setter Property="Cursor" Value="Ibeam" />
+                                    </Style>
+                                </ScrollViewer.Styles>
                             </ScrollViewer>
                             <Button
                                 Name="PART_ClearButton"


### PR DESCRIPTION
<img width="341" height="188" alt="before" src="https://github.com/user-attachments/assets/ab9b74e7-cd4c-4633-ba80-51e79b2a8c8f" />
<img width="334" height="188" alt="after" src="https://github.com/user-attachments/assets/d62f6f7a-8325-4ff7-b72b-5f098febbae8" />
