### PR TITLE
This pull request adds additional localisation resources 

### DIFF
--- a/demo/Semi.Avalonia.Demo/Views/MainView.axaml.cs
+++ b/demo/Semi.Avalonia.Demo/Views/MainView.axaml.cs
@@ -92,6 +92,42 @@ public partial class MainViewModel : ObservableObject
                     },
                     new MenuItemViewModel
                     {
+                        Header = "한국어",
+                        Command = SelectLocaleCommand,
+                        CommandParameter = new CultureInfo("ko-kr")
+                    },
+                    new MenuItemViewModel
+                    {
+                        Header = "English (UK)",
+                        Command = SelectLocaleCommand,
+                        CommandParameter = new CultureInfo("en-gb")
+                    },
+                    new MenuItemViewModel
+                    {
+                        Header = "Italiano",
+                        Command = SelectLocaleCommand,
+                        CommandParameter = new CultureInfo("it-it")
+                    },
+                    new MenuItemViewModel
+                    {
+                        Header = "Italiano (Switzerland)",
+                        Command = SelectLocaleCommand,
+                        CommandParameter = new CultureInfo("it-ch")
+                    },
+                    new MenuItemViewModel
+                    {
+                        Header = "Nederlands",
+                        Command = SelectLocaleCommand,
+                        CommandParameter = new CultureInfo("nl-nl")
+                    },
+                    new MenuItemViewModel
+                    {
+                        Header = "Nederlands (Belgium)",
+                        Command = SelectLocaleCommand,
+                        CommandParameter = new CultureInfo("nl-be")
+                    },
+                    new MenuItemViewModel
+                    {
                         Header = "Українська",
                         Command = SelectLocaleCommand,
                         CommandParameter = new CultureInfo("uk-ua")

--- a/src/Semi.Avalonia/Locale/_index.cs
+++ b/src/Semi.Avalonia/Locale/_index.cs
@@ -6,11 +6,23 @@ public class de_de : ResourceDictionary;
 
 public class en_us : ResourceDictionary;
 
+public class en_gb : ResourceDictionary;
+
+public class it_it : ResourceDictionary;
+
+public class it_ch : ResourceDictionary;
+
+public class nl_be : ResourceDictionary;
+
+public class nl_nl : ResourceDictionary;
+
 public class es_es : ResourceDictionary;
 
 public class fr_fr : ResourceDictionary;
 
 public class ja_jp : ResourceDictionary;
+
+public class ko_kr : ResourceDictionary;
 
 public class pl_pl : ResourceDictionary;
 

--- a/src/Semi.Avalonia/Locale/en-gb.axaml
+++ b/src/Semi.Avalonia/Locale/en-gb.axaml
@@ -1,0 +1,27 @@
+﻿<ResourceDictionary
+    x:Class="Semi.Avalonia.Locale.en_gb"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!--  DatePicker  -->
+    <x:String x:Key="STRING_DATEPICKER_DAY_TEXT">day</x:String>
+    <x:String x:Key="STRING_DATEPICKER_MONTH_TEXT">month</x:String>
+    <x:String x:Key="STRING_DATEPICKER_YEAR_TEXT">year</x:String>
+    <!--  TimePicker  -->
+    <x:String x:Key="STRING_TIMEPICKER_HOUR_TEXT">hour</x:String>
+    <x:String x:Key="STRING_TIMEPICKER_MINUTE_TEXT">minute</x:String>
+    <x:String x:Key="STRING_TIMEPICKER_SECOND_TEXT">second</x:String>
+    <!-- TextBox/SelectableTextBox flyout -->
+    <x:String x:Key="STRING_MENU_CUT">Cut</x:String>
+    <x:String x:Key="STRING_MENU_COPY">Copy</x:String>
+    <x:String x:Key="STRING_MENU_PASTE">Paste</x:String>
+    <!--  ManagedFileChooser  -->
+    <x:String x:Key="STRING_CHOOSER_FILE_NAME">File name</x:String>
+    <x:String x:Key="STRING_CHOOSER_SHOW_HIDDEN_FILES">Show hidden files</x:String>
+    <x:String x:Key="STRING_CHOOSER_DIALOG_OK">OK</x:String>
+    <x:String x:Key="STRING_CHOOSER_DIALOG_CANCEL">Cancel</x:String>
+    <x:String x:Key="STRING_CHOOSER_NAME_COLUMN">Name</x:String>
+    <x:String x:Key="STRING_CHOOSER_DATEMODIFIED_COLUMN">Date Modified</x:String>
+    <x:String x:Key="STRING_CHOOSER_TYPE_COLUMN">Type</x:String>
+    <x:String x:Key="STRING_CHOOSER_SIZE_COLUMN">Size</x:String>
+    <x:String x:Key="STRING_CHOOSER_PROMPT_FILE_ALREADY_EXISTS">{0} already exists. Do you want to replace it?</x:String>
+</ResourceDictionary>

--- a/src/Semi.Avalonia/Locale/it-ch.axaml
+++ b/src/Semi.Avalonia/Locale/it-ch.axaml
@@ -16,7 +16,7 @@
     <x:String x:Key="STRING_MENU_PASTE">Incolla</x:String>
     <!--  ManagedFileChooser  -->
     <x:String x:Key="STRING_CHOOSER_FILE_NAME">Nome file</x:String>
-    <x:String x:Key="STRING_CHOOSER_SHOW_HIDDEN_FILES">Mostra files nascosti</x:String>
+    <x:String x:Key="STRING_CHOOSER_SHOW_HIDDEN_FILES">Mostra file nascosti</x:String>
     <x:String x:Key="STRING_CHOOSER_DIALOG_OK">OK</x:String>
     <x:String x:Key="STRING_CHOOSER_DIALOG_CANCEL">Annulla</x:String>
     <x:String x:Key="STRING_CHOOSER_NAME_COLUMN">Nome</x:String>

--- a/src/Semi.Avalonia/Locale/it-ch.axaml
+++ b/src/Semi.Avalonia/Locale/it-ch.axaml
@@ -1,0 +1,27 @@
+﻿<ResourceDictionary
+    x:Class="Semi.Avalonia.Locale.it_ch"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!--  DatePicker  -->
+    <x:String x:Key="STRING_DATEPICKER_DAY_TEXT">giorno</x:String>
+    <x:String x:Key="STRING_DATEPICKER_MONTH_TEXT">mese</x:String>
+    <x:String x:Key="STRING_DATEPICKER_YEAR_TEXT">anno</x:String>
+    <!--  TimePicker  -->
+    <x:String x:Key="STRING_TIMEPICKER_HOUR_TEXT">ora</x:String>
+    <x:String x:Key="STRING_TIMEPICKER_MINUTE_TEXT">minuto</x:String>
+    <x:String x:Key="STRING_TIMEPICKER_SECOND_TEXT">secondo</x:String>
+    <!-- TextBox/SelectableTextBox flyout -->
+    <x:String x:Key="STRING_MENU_CUT">Taglia</x:String>
+    <x:String x:Key="STRING_MENU_COPY">Copia</x:String>
+    <x:String x:Key="STRING_MENU_PASTE">Incolla</x:String>
+    <!--  ManagedFileChooser  -->
+    <x:String x:Key="STRING_CHOOSER_FILE_NAME">Nome file</x:String>
+    <x:String x:Key="STRING_CHOOSER_SHOW_HIDDEN_FILES">Mostra files nascosti</x:String>
+    <x:String x:Key="STRING_CHOOSER_DIALOG_OK">OK</x:String>
+    <x:String x:Key="STRING_CHOOSER_DIALOG_CANCEL">Annulla</x:String>
+    <x:String x:Key="STRING_CHOOSER_NAME_COLUMN">Nome</x:String>
+    <x:String x:Key="STRING_CHOOSER_DATEMODIFIED_COLUMN">Data Modificata</x:String>
+    <x:String x:Key="STRING_CHOOSER_TYPE_COLUMN">Tipo</x:String>
+    <x:String x:Key="STRING_CHOOSER_SIZE_COLUMN">Dimensione</x:String>
+    <x:String x:Key="STRING_CHOOSER_PROMPT_FILE_ALREADY_EXISTS">{0} è già esistente. Sovrascriverlo?</x:String>
+</ResourceDictionary>

--- a/src/Semi.Avalonia/Locale/it-it.axaml
+++ b/src/Semi.Avalonia/Locale/it-it.axaml
@@ -16,7 +16,7 @@
     <x:String x:Key="STRING_MENU_PASTE">Incolla</x:String>
     <!--  ManagedFileChooser  -->
     <x:String x:Key="STRING_CHOOSER_FILE_NAME">Nome file</x:String>
-    <x:String x:Key="STRING_CHOOSER_SHOW_HIDDEN_FILES">Mostra files nascosti</x:String>
+    <x:String x:Key="STRING_CHOOSER_SHOW_HIDDEN_FILES">Mostra file nascosti</x:String>
     <x:String x:Key="STRING_CHOOSER_DIALOG_OK">OK</x:String>
     <x:String x:Key="STRING_CHOOSER_DIALOG_CANCEL">Annulla</x:String>
     <x:String x:Key="STRING_CHOOSER_NAME_COLUMN">Nome</x:String>

--- a/src/Semi.Avalonia/Locale/it-it.axaml
+++ b/src/Semi.Avalonia/Locale/it-it.axaml
@@ -1,0 +1,27 @@
+﻿<ResourceDictionary
+    x:Class="Semi.Avalonia.Locale.it_it"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!--  DatePicker  -->
+    <x:String x:Key="STRING_DATEPICKER_DAY_TEXT">giorno</x:String>
+    <x:String x:Key="STRING_DATEPICKER_MONTH_TEXT">mese</x:String>
+    <x:String x:Key="STRING_DATEPICKER_YEAR_TEXT">anno</x:String>
+    <!--  TimePicker  -->
+    <x:String x:Key="STRING_TIMEPICKER_HOUR_TEXT">ora</x:String>
+    <x:String x:Key="STRING_TIMEPICKER_MINUTE_TEXT">minuto</x:String>
+    <x:String x:Key="STRING_TIMEPICKER_SECOND_TEXT">secondo</x:String>
+    <!-- TextBox/SelectableTextBox flyout -->
+    <x:String x:Key="STRING_MENU_CUT">Taglia</x:String>
+    <x:String x:Key="STRING_MENU_COPY">Copia</x:String>
+    <x:String x:Key="STRING_MENU_PASTE">Incolla</x:String>
+    <!--  ManagedFileChooser  -->
+    <x:String x:Key="STRING_CHOOSER_FILE_NAME">Nome file</x:String>
+    <x:String x:Key="STRING_CHOOSER_SHOW_HIDDEN_FILES">Mostra files nascosti</x:String>
+    <x:String x:Key="STRING_CHOOSER_DIALOG_OK">OK</x:String>
+    <x:String x:Key="STRING_CHOOSER_DIALOG_CANCEL">Annulla</x:String>
+    <x:String x:Key="STRING_CHOOSER_NAME_COLUMN">Nome</x:String>
+    <x:String x:Key="STRING_CHOOSER_DATEMODIFIED_COLUMN">Data Modificata</x:String>
+    <x:String x:Key="STRING_CHOOSER_TYPE_COLUMN">Tipo</x:String>
+    <x:String x:Key="STRING_CHOOSER_SIZE_COLUMN">Dimensione</x:String>
+    <x:String x:Key="STRING_CHOOSER_PROMPT_FILE_ALREADY_EXISTS">{0} è già esistente. Sovrascriverlo?</x:String>
+</ResourceDictionary>

--- a/src/Semi.Avalonia/Locale/ko-kr.axaml
+++ b/src/Semi.Avalonia/Locale/ko-kr.axaml
@@ -1,0 +1,27 @@
+﻿<ResourceDictionary
+    x:Class="Semi.Avalonia.Locale.ko_kr"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- DatePicker -->
+    <x:String x:Key="STRING_DATEPICKER_DAY_TEXT">일</x:String>
+    <x:String x:Key="STRING_DATEPICKER_MONTH_TEXT">월</x:String>
+    <x:String x:Key="STRING_DATEPICKER_YEAR_TEXT">년</x:String>
+    <!-- TimePicker -->
+    <x:String x:Key="STRING_TIMEPICKER_HOUR_TEXT">시</x:String>
+    <x:String x:Key="STRING_TIMEPICKER_MINUTE_TEXT">분</x:String>
+    <x:String x:Key="STRING_TIMEPICKER_SECOND_TEXT">초</x:String>
+    <!-- TextBox/SelectableTextBox flyout -->
+    <x:String x:Key="STRING_MENU_CUT">잘라내기</x:String>
+    <x:String x:Key="STRING_MENU_COPY">복사</x:String>
+    <x:String x:Key="STRING_MENU_PASTE">붙여넣기</x:String>
+    <!-- ManagedFileChooser -->
+    <x:String x:Key="STRING_CHOOSER_FILE_NAME">파일 이름</x:String>
+    <x:String x:Key="STRING_CHOOSER_SHOW_HIDDEN_FILES">숨긴 파일 표시</x:String>
+    <x:String x:Key="STRING_CHOOSER_DIALOG_OK">확인</x:String>
+    <x:String x:Key="STRING_CHOOSER_DIALOG_CANCEL">취소</x:String>
+    <x:String x:Key="STRING_CHOOSER_NAME_COLUMN">이름</x:String>
+    <x:String x:Key="STRING_CHOOSER_DATEMODIFIED_COLUMN">수정된 날짜</x:String>
+    <x:String x:Key="STRING_CHOOSER_TYPE_COLUMN">유형</x:String>
+    <x:String x:Key="STRING_CHOOSER_SIZE_COLUMN">크기</x:String>
+    <x:String x:Key="STRING_CHOOSER_PROMPT_FILE_ALREADY_EXISTS">{0}이(가) 이미 있습니다. 바꾸시겠습니까?</x:String>
+</ResourceDictionary>

--- a/src/Semi.Avalonia/Locale/nl-be.axaml
+++ b/src/Semi.Avalonia/Locale/nl-be.axaml
@@ -1,0 +1,27 @@
+﻿<ResourceDictionary
+    x:Class="Semi.Avalonia.Locale.nl_be"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- DatePicker -->
+    <x:String x:Key="STRING_DATEPICKER_DAY_TEXT">dag</x:String>
+    <x:String x:Key="STRING_DATEPICKER_MONTH_TEXT">maand</x:String>
+    <x:String x:Key="STRING_DATEPICKER_YEAR_TEXT">jaar</x:String>
+    <!-- TimePicker -->
+    <x:String x:Key="STRING_TIMEPICKER_HOUR_TEXT">uur</x:String>
+    <x:String x:Key="STRING_TIMEPICKER_MINUTE_TEXT">minuut</x:String>
+    <x:String x:Key="STRING_TIMEPICKER_SECOND_TEXT">seconde</x:String>
+    <!-- TextBox/SelectableTextBox flyout -->
+    <x:String x:Key="STRING_MENU_CUT">Knippen</x:String>
+    <x:String x:Key="STRING_MENU_COPY">Kopiëren</x:String>
+    <x:String x:Key="STRING_MENU_PASTE">Plakken</x:String>
+    <!-- ManagedFileChooser -->
+    <x:String x:Key="STRING_CHOOSER_FILE_NAME">Bestandsnaam</x:String>
+    <x:String x:Key="STRING_CHOOSER_SHOW_HIDDEN_FILES">Toon verborgen bestanden</x:String>
+    <x:String x:Key="STRING_CHOOSER_DIALOG_OK">OK</x:String>
+    <x:String x:Key="STRING_CHOOSER_DIALOG_CANCEL">Annuleren</x:String>
+    <x:String x:Key="STRING_CHOOSER_NAME_COLUMN">Naam</x:String>
+    <x:String x:Key="STRING_CHOOSER_DATEMODIFIED_COLUMN">Datum gewijzigd</x:String>
+    <x:String x:Key="STRING_CHOOSER_TYPE_COLUMN">Type</x:String>
+    <x:String x:Key="STRING_CHOOSER_SIZE_COLUMN">Grootte</x:String>
+    <x:String x:Key="STRING_CHOOSER_PROMPT_FILE_ALREADY_EXISTS">{0} bestaat al. Wilt u het vervangen?</x:String>
+</ResourceDictionary>

--- a/src/Semi.Avalonia/Locale/nl-nl.axaml
+++ b/src/Semi.Avalonia/Locale/nl-nl.axaml
@@ -1,0 +1,27 @@
+﻿<ResourceDictionary
+    x:Class="Semi.Avalonia.Locale.nl_nl"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- DatePicker -->
+    <x:String x:Key="STRING_DATEPICKER_DAY_TEXT">dag</x:String>
+    <x:String x:Key="STRING_DATEPICKER_MONTH_TEXT">maand</x:String>
+    <x:String x:Key="STRING_DATEPICKER_YEAR_TEXT">jaar</x:String>
+    <!-- TimePicker -->
+    <x:String x:Key="STRING_TIMEPICKER_HOUR_TEXT">uur</x:String>
+    <x:String x:Key="STRING_TIMEPICKER_MINUTE_TEXT">minuut</x:String>
+    <x:String x:Key="STRING_TIMEPICKER_SECOND_TEXT">seconde</x:String>
+    <!-- TextBox/SelectableTextBox flyout -->
+    <x:String x:Key="STRING_MENU_CUT">Knippen</x:String>
+    <x:String x:Key="STRING_MENU_COPY">Kopiëren</x:String>
+    <x:String x:Key="STRING_MENU_PASTE">Plakken</x:String>
+    <!-- ManagedFileChooser -->
+    <x:String x:Key="STRING_CHOOSER_FILE_NAME">Bestandsnaam</x:String>
+    <x:String x:Key="STRING_CHOOSER_SHOW_HIDDEN_FILES">Toon verborgen bestanden</x:String>
+    <x:String x:Key="STRING_CHOOSER_DIALOG_OK">OK</x:String>
+    <x:String x:Key="STRING_CHOOSER_DIALOG_CANCEL">Annuleren</x:String>
+    <x:String x:Key="STRING_CHOOSER_NAME_COLUMN">Naam</x:String>
+    <x:String x:Key="STRING_CHOOSER_DATEMODIFIED_COLUMN">Datum gewijzigd</x:String>
+    <x:String x:Key="STRING_CHOOSER_TYPE_COLUMN">Type</x:String>
+    <x:String x:Key="STRING_CHOOSER_SIZE_COLUMN">Grootte</x:String>
+    <x:String x:Key="STRING_CHOOSER_PROMPT_FILE_ALREADY_EXISTS">{0} bestaat al. Wilt u het vervangen?</x:String>
+</ResourceDictionary>

--- a/src/Semi.Avalonia/SemiTheme.axaml.cs
+++ b/src/Semi.Avalonia/SemiTheme.axaml.cs
@@ -15,6 +15,11 @@ public class SemiTheme : Styles
     {
         { new CultureInfo("zh-cn"), new zh_cn() },
         { new CultureInfo("en-us"), new en_us() },
+        { new CultureInfo("en-gb"), new en_gb() },
+        { new CultureInfo("it-it"), new it_it() },
+        { new CultureInfo("it-ch"), new it_ch() },
+        { new CultureInfo("nl-be"), new nl_be() },
+        { new CultureInfo("nl-nl"), new nl_nl() },
         { new CultureInfo("ja-jp"), new ja_jp() },
         { new CultureInfo("uk-ua"), new uk_ua() },
         { new CultureInfo("ru-ru"), new ru_ru() },

--- a/src/Semi.Avalonia/SemiTheme.axaml.cs
+++ b/src/Semi.Avalonia/SemiTheme.axaml.cs
@@ -21,6 +21,7 @@ public class SemiTheme : Styles
         { new CultureInfo("nl-be"), new nl_be() },
         { new CultureInfo("nl-nl"), new nl_nl() },
         { new CultureInfo("ja-jp"), new ja_jp() },
+        { new CultureInfo("ko-kr"), new ko_kr() },
         { new CultureInfo("uk-ua"), new uk_ua() },
         { new CultureInfo("ru-ru"), new ru_ru() },
         { new CultureInfo("zh-tw"), new zh_tw() },


### PR DESCRIPTION
**Added locales**

- it-IT – Italian (Italy)
- it-CH – Italian (Switzerland)
- nl-NL – Dutch (Netherlands)
- nl-BE – Dutch (Belgium)
- ko-KR – Korean (Korea)
- en-GB – English (United Kingdom)

Extends the theme with broader language coverage so that developers can provide a more consistent experience for international users.

**Notes**
No existing resources were altered.
The update is limited to new locale additions; no breaking changes introduced.
Added BE, CH and GB since I need those locales in a private app, otherwise Semi would default to Chinese