### PR TITLE
Add AI style - Colorful & Gradient to TagLabel

### DIFF
--- a/demo/Semi.Avalonia.Demo/Pages/ButtonDemo.axaml
+++ b/demo/Semi.Avalonia.Demo/Pages/ButtonDemo.axaml
@@ -113,18 +113,18 @@
                 Theme="{StaticResource GroupBox}">
                 <HeaderedContentControl.Header>
                     <StackPanel Spacing="8">
-                        <TextBlock Text="AI style - Colorful buttons" />
+                        <TextBlock Text="AI style - Colorful Button" />
                         <WrapPanel ItemSpacing="4">
                             <TextBlock Text="Theme:" />
-                            <Label Theme="{StaticResource TagLabel}" Classes="Colorful Solid" Content="Light" />
-                            <Label Theme="{StaticResource TagLabel}" Classes="Colorful Solid" Content="Solid" />
-                            <Label Theme="{StaticResource TagLabel}" Classes="Colorful Solid" Content="Outline" />
-                            <Label Theme="{StaticResource TagLabel}" Classes="Colorful Solid" Content="Borderless" />
+                            <Label Theme="{StaticResource TagLabel}" Classes="Colorful Gradient Solid" Content="Light" />
+                            <Label Theme="{StaticResource TagLabel}" Classes="Colorful Gradient Solid" Content="Solid" />
+                            <Label Theme="{StaticResource TagLabel}" Classes="Colorful Gradient Solid" Content="Outline" />
+                            <Label Theme="{StaticResource TagLabel}" Classes="Colorful Gradient Solid" Content="Borderless" />
                         </WrapPanel>
                         <WrapPanel ItemSpacing="4">
                             <TextBlock Text="Classes:" />
-                            <Label Theme="{StaticResource TagLabel}" Classes="Colorful" Content="Colorful Primary" />
-                            <Label Theme="{StaticResource TagLabel}" Classes="Colorful" Content="Colorful Tertiary" />
+                            <Label Theme="{StaticResource TagLabel}" Classes="Colorful Gradient" Content="Colorful Primary" />
+                            <Label Theme="{StaticResource TagLabel}" Classes="Colorful Gradient" Content="Colorful Tertiary" />
                         </WrapPanel>
                     </StackPanel>
                 </HeaderedContentControl.Header>

--- a/demo/Semi.Avalonia.Demo/Pages/LabelDemo.axaml
+++ b/demo/Semi.Avalonia.Demo/Pages/LabelDemo.axaml
@@ -8,14 +8,11 @@
     d:DesignWidth="800"
     mc:Ignorable="d">
     <ScrollViewer>
-        <StackPanel HorizontalAlignment="Left" Spacing="20">
+        <StackPanel>
             <StackPanel.Styles>
-                <Style Selector="Label">
-                    <Setter Property="Margin" Value="4" />
-                </Style>
-                <Style Selector="Grid > TextBlock">
-                    <Setter Property="VerticalAlignment" Value="Center" />
-                    <Setter Property="Margin" Value="4" />
+                <Style Selector="Grid > TextBlock,Grid > Label">
+                    <Setter Property="Layoutable.VerticalAlignment" Value="Center" />
+                    <Setter Property="Layoutable.Margin" Value="4" />
                 </Style>
             </StackPanel.Styles>
             <ScrollViewer HorizontalScrollBarVisibility="Auto">
@@ -156,69 +153,89 @@
                     </HeaderedContentControl>
                 </StackPanel>
             </ScrollViewer>
-            <WrapPanel>
-                <Label Theme="{StaticResource TagLabel}">Label</Label>
-                <Label Classes="Large" Theme="{StaticResource TagLabel}">Large Label</Label>
-                <Label Classes="Circle" Theme="{StaticResource TagLabel}">Circle Label</Label>
-                <Label Classes="Large Circle" Theme="{StaticResource TagLabel}">Large Circle Label</Label>
-            </WrapPanel>
-            <WrapPanel>
-                <Label Classes="Red" Theme="{StaticResource TagLabel}">Red</Label>
-                <Label Classes="Pink" Theme="{StaticResource TagLabel}">Pink</Label>
-                <Label Classes="Purple" Theme="{StaticResource TagLabel}">Purple</Label>
-                <Label Classes="Violet" Theme="{StaticResource TagLabel}">Violet</Label>
-                <Label Classes="Indigo" Theme="{StaticResource TagLabel}">Indigo</Label>
-                <Label Classes="Blue" Theme="{StaticResource TagLabel}">Blue</Label>
-                <Label Classes="LightBlue" Theme="{StaticResource TagLabel}">LightBlue</Label>
-                <Label Classes="Cyan" Theme="{StaticResource TagLabel}">Cyan</Label>
-                <Label Classes="Teal" Theme="{StaticResource TagLabel}">Teal</Label>
-                <Label Classes="Green" Theme="{StaticResource TagLabel}">Green</Label>
-                <Label Classes="LightGreen" Theme="{StaticResource TagLabel}">LightGreen</Label>
-                <Label Classes="Lime" Theme="{StaticResource TagLabel}">Lime</Label>
-                <Label Classes="Yellow" Theme="{StaticResource TagLabel}">Yellow</Label>
-                <Label Classes="Amber" Theme="{StaticResource TagLabel}">Amber</Label>
-                <Label Classes="Orange" Theme="{StaticResource TagLabel}">Orange</Label>
-                <Label Classes="Grey" Theme="{StaticResource TagLabel}">Grey</Label>
-                <Label Classes="White" Theme="{StaticResource TagLabel}">White</Label>
-            </WrapPanel>
-            <WrapPanel>
-                <Label Classes="Ghost Red" Theme="{StaticResource TagLabel}">Red</Label>
-                <Label Classes="Ghost Pink" Theme="{StaticResource TagLabel}">Pink</Label>
-                <Label Classes="Ghost Purple" Theme="{StaticResource TagLabel}">Purple</Label>
-                <Label Classes="Ghost Violet" Theme="{StaticResource TagLabel}">Violet</Label>
-                <Label Classes="Ghost Indigo" Theme="{StaticResource TagLabel}">Indigo</Label>
-                <Label Classes="Ghost Blue" Theme="{StaticResource TagLabel}">Blue</Label>
-                <Label Classes="Ghost LightBlue" Theme="{StaticResource TagLabel}">LightBlue</Label>
-                <Label Classes="Ghost Cyan" Theme="{StaticResource TagLabel}">Cyan</Label>
-                <Label Classes="Ghost Teal" Theme="{StaticResource TagLabel}">Teal</Label>
-                <Label Classes="Ghost Green" Theme="{StaticResource TagLabel}">Green</Label>
-                <Label Classes="Ghost LightGreen" Theme="{StaticResource TagLabel}">LightGreen</Label>
-                <Label Classes="Ghost Lime" Theme="{StaticResource TagLabel}">Lime</Label>
-                <Label Classes="Ghost Yellow" Theme="{StaticResource TagLabel}">Yellow</Label>
-                <Label Classes="Ghost Amber" Theme="{StaticResource TagLabel}">Amber</Label>
-                <Label Classes="Ghost Orange" Theme="{StaticResource TagLabel}">Orange</Label>
-                <Label Classes="Ghost Grey" Theme="{StaticResource TagLabel}">Grey</Label>
-                <Label Classes="Ghost White" Theme="{StaticResource TagLabel}">White</Label>
-            </WrapPanel>
-            <WrapPanel>
-                <Label Classes="Solid Red" Theme="{StaticResource TagLabel}">Red</Label>
-                <Label Classes="Solid Pink" Theme="{StaticResource TagLabel}">Pink</Label>
-                <Label Classes="Solid Purple" Theme="{StaticResource TagLabel}">Purple</Label>
-                <Label Classes="Solid Violet" Theme="{StaticResource TagLabel}">Violet</Label>
-                <Label Classes="Solid Indigo" Theme="{StaticResource TagLabel}">Indigo</Label>
-                <Label Classes="Solid Blue" Theme="{StaticResource TagLabel}">Blue</Label>
-                <Label Classes="Solid LightBlue" Theme="{StaticResource TagLabel}">LightBlue</Label>
-                <Label Classes="Solid Cyan" Theme="{StaticResource TagLabel}">Cyan</Label>
-                <Label Classes="Solid Teal" Theme="{StaticResource TagLabel}">Teal</Label>
-                <Label Classes="Solid Green" Theme="{StaticResource TagLabel}">Green</Label>
-                <Label Classes="Solid LightGreen" Theme="{StaticResource TagLabel}">LightGreen</Label>
-                <Label Classes="Solid Lime" Theme="{StaticResource TagLabel}">Lime</Label>
-                <Label Classes="Solid Yellow" Theme="{StaticResource TagLabel}">Yellow</Label>
-                <Label Classes="Solid Amber" Theme="{StaticResource TagLabel}">Amber</Label>
-                <Label Classes="Solid Orange" Theme="{StaticResource TagLabel}">Orange</Label>
-                <Label Classes="Solid Grey" Theme="{StaticResource TagLabel}">Grey</Label>
-                <Label Classes="Solid White" Theme="{StaticResource TagLabel}">White</Label>
-            </WrapPanel>
+
+            <HeaderedContentControl
+                Margin="16"
+                Header="Theme: TagLabel"
+                Theme="{DynamicResource GroupBox}">
+                <ScrollViewer HorizontalScrollBarVisibility="Auto">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <StackPanel Spacing="4">
+                            <Label Classes="Red" Theme="{StaticResource TagLabel}">Red</Label>
+                            <Label Classes="Pink" Theme="{StaticResource TagLabel}">Pink</Label>
+                            <Label Classes="Purple" Theme="{StaticResource TagLabel}">Purple</Label>
+                            <Label Classes="Violet" Theme="{StaticResource TagLabel}">Violet</Label>
+                            <Label Classes="Indigo" Theme="{StaticResource TagLabel}">Indigo</Label>
+                            <Label Classes="Blue" Theme="{StaticResource TagLabel}">Blue</Label>
+                            <Label Classes="LightBlue" Theme="{StaticResource TagLabel}">LightBlue</Label>
+                            <Label Classes="Cyan" Theme="{StaticResource TagLabel}">Cyan</Label>
+                            <Label Classes="Teal" Theme="{StaticResource TagLabel}">Teal</Label>
+                            <Label Classes="Green" Theme="{StaticResource TagLabel}">Green</Label>
+                            <Label Classes="LightGreen" Theme="{StaticResource TagLabel}">LightGreen</Label>
+                            <Label Classes="Lime" Theme="{StaticResource TagLabel}">Lime</Label>
+                            <Label Classes="Yellow" Theme="{StaticResource TagLabel}">Yellow</Label>
+                            <Label Classes="Amber" Theme="{StaticResource TagLabel}">Amber</Label>
+                            <Label Classes="Orange" Theme="{StaticResource TagLabel}">Orange</Label>
+                            <Label Classes="Grey" Theme="{StaticResource TagLabel}">Grey</Label>
+                            <Label Classes="White" Theme="{StaticResource TagLabel}">White</Label>
+                        </StackPanel>
+                        <StackPanel Spacing="4">
+                            <Label Classes="Ghost Red" Theme="{StaticResource TagLabel}">Red</Label>
+                            <Label Classes="Ghost Pink" Theme="{StaticResource TagLabel}">Pink</Label>
+                            <Label Classes="Ghost Purple" Theme="{StaticResource TagLabel}">Purple</Label>
+                            <Label Classes="Ghost Violet" Theme="{StaticResource TagLabel}">Violet</Label>
+                            <Label Classes="Ghost Indigo" Theme="{StaticResource TagLabel}">Indigo</Label>
+                            <Label Classes="Ghost Blue" Theme="{StaticResource TagLabel}">Blue</Label>
+                            <Label Classes="Ghost LightBlue" Theme="{StaticResource TagLabel}">LightBlue</Label>
+                            <Label Classes="Ghost Cyan" Theme="{StaticResource TagLabel}">Cyan</Label>
+                            <Label Classes="Ghost Teal" Theme="{StaticResource TagLabel}">Teal</Label>
+                            <Label Classes="Ghost Green" Theme="{StaticResource TagLabel}">Green</Label>
+                            <Label Classes="Ghost LightGreen" Theme="{StaticResource TagLabel}">LightGreen</Label>
+                            <Label Classes="Ghost Lime" Theme="{StaticResource TagLabel}">Lime</Label>
+                            <Label Classes="Ghost Yellow" Theme="{StaticResource TagLabel}">Yellow</Label>
+                            <Label Classes="Ghost Amber" Theme="{StaticResource TagLabel}">Amber</Label>
+                            <Label Classes="Ghost Orange" Theme="{StaticResource TagLabel}">Orange</Label>
+                            <Label Classes="Ghost Grey" Theme="{StaticResource TagLabel}">Grey</Label>
+                            <Label Classes="Ghost White" Theme="{StaticResource TagLabel}">White</Label>
+                        </StackPanel>
+                        <StackPanel Spacing="4">
+                            <Label Classes="Solid Red" Theme="{StaticResource TagLabel}">Red</Label>
+                            <Label Classes="Solid Pink" Theme="{StaticResource TagLabel}">Pink</Label>
+                            <Label Classes="Solid Purple" Theme="{StaticResource TagLabel}">Purple</Label>
+                            <Label Classes="Solid Violet" Theme="{StaticResource TagLabel}">Violet</Label>
+                            <Label Classes="Solid Indigo" Theme="{StaticResource TagLabel}">Indigo</Label>
+                            <Label Classes="Solid Blue" Theme="{StaticResource TagLabel}">Blue</Label>
+                            <Label Classes="Solid LightBlue" Theme="{StaticResource TagLabel}">LightBlue</Label>
+                            <Label Classes="Solid Cyan" Theme="{StaticResource TagLabel}">Cyan</Label>
+                            <Label Classes="Solid Teal" Theme="{StaticResource TagLabel}">Teal</Label>
+                            <Label Classes="Solid Green" Theme="{StaticResource TagLabel}">Green</Label>
+                            <Label Classes="Solid LightGreen" Theme="{StaticResource TagLabel}">LightGreen</Label>
+                            <Label Classes="Solid Lime" Theme="{StaticResource TagLabel}">Lime</Label>
+                            <Label Classes="Solid Yellow" Theme="{StaticResource TagLabel}">Yellow</Label>
+                            <Label Classes="Solid Amber" Theme="{StaticResource TagLabel}">Amber</Label>
+                            <Label Classes="Solid Orange" Theme="{StaticResource TagLabel}">Orange</Label>
+                            <Label Classes="Solid Grey" Theme="{StaticResource TagLabel}">Grey</Label>
+                            <Label Classes="Solid White" Theme="{StaticResource TagLabel}">White</Label>
+                        </StackPanel>
+                        <StackPanel Spacing="4">
+                            <Label Classes="Colorful Gradient" Theme="{DynamicResource TagLabel}">Light</Label>
+                            <Label Classes="Colorful Gradient Ghost" Theme="{DynamicResource TagLabel}">Ghost</Label>
+                            <Label Classes="Colorful Gradient Solid" Theme="{DynamicResource TagLabel}">Solid</Label>
+                        </StackPanel>
+                        <StackPanel Spacing="4">
+                            <Label Classes="Colorful" Theme="{DynamicResource TagLabel}">Light</Label>
+                            <Label Classes="Colorful Ghost" Theme="{DynamicResource TagLabel}">Ghost</Label>
+                            <Label Classes="Colorful Solid" Theme="{DynamicResource TagLabel}">Solid</Label>
+                        </StackPanel>
+                        <StackPanel Spacing="4">
+                            <Label Theme="{StaticResource TagLabel}">Label</Label>
+                            <Label Classes="Large" Theme="{StaticResource TagLabel}">Large Label</Label>
+                            <Label Classes="Circle" Theme="{StaticResource TagLabel}">Circle Label</Label>
+                            <Label Classes="Large Circle" Theme="{StaticResource TagLabel}">Large Circle Label</Label>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+            </HeaderedContentControl>
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/src/Semi.Avalonia/Controls/Label.axaml
+++ b/src/Semi.Avalonia/Controls/Label.axaml
@@ -75,7 +75,16 @@
                 <Label Classes="Solid Grey" Theme="{StaticResource TagLabel}">Grey</Label>
                 <Label Classes="Solid White" Theme="{StaticResource TagLabel}">White</Label>
             </WrapPanel>
-
+            <WrapPanel>
+                <Label Classes="Colorful Gradient" Theme="{DynamicResource TagLabel}">AI</Label>
+                <Label Classes="Colorful Gradient Ghost" Theme="{DynamicResource TagLabel}">AI</Label>
+                <Label Classes="Colorful Gradient Solid" Theme="{DynamicResource TagLabel}">AI</Label>
+            </WrapPanel>
+            <WrapPanel>
+                <Label Classes="Colorful" Theme="{DynamicResource TagLabel}">AI</Label>
+                <Label Classes="Colorful Ghost" Theme="{DynamicResource TagLabel}">AI</Label>
+                <Label Classes="Colorful Solid" Theme="{DynamicResource TagLabel}">AI</Label>
+            </WrapPanel>
         </StackPanel>
     </Design.PreviewWith>
     <ControlTheme x:Key="{x:Type Label}" TargetType="Label">
@@ -162,6 +171,7 @@
     <!--  Shape: Square,Circle. Default is Square  -->
     <!--  Size: Small, Large. Default is Small  -->
     <!--  Color: Red, Pink, Purple, Violet, Indigo, Blue, LightBlue, Cyan, Teal, Green, LightGreen, Lime, Yellow, Amber, Orange, Grey, White. Default is Grey  -->
+    <!--  AI style: Colorful, Gradient  -->
     <ControlTheme x:Key="TagLabel" TargetType="Label">
         <Setter Property="BorderThickness" Value="{DynamicResource LabelTagBorderThickness}" />
         <Setter Property="MinHeight" Value="{DynamicResource LabelTagSmallHeight}" />
@@ -394,6 +404,35 @@
             <Setter Property="Foreground" Value="{DynamicResource LabelTagSolidWhiteForeground}" />
             <Setter Property="BorderBrush" Value="{DynamicResource LabelTagSolidWhiteBorderBrush}" />
             <Setter Property="Background" Value="{DynamicResource LabelTagSolidWhiteBackground}" />
+        </Style>
+
+        <Style Selector="^.Colorful">
+            <Setter Property="FontWeight" Value="{StaticResource LabelTagColorfulFontWeight}" />
+
+            <Setter Property="Foreground" Value="{DynamicResource LabelTagColorfulLightForeground}" />
+            <Setter Property="Background" Value="{DynamicResource LabelTagColorfulLightBackground}" />
+            <Style Selector="^.Ghost">
+                <Setter Property="Foreground" Value="{DynamicResource LabelTagColorfulGhostForeground}" />
+                <Setter Property="Background" Value="{DynamicResource LabelTagColorfulGhostBackground}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource LabelTagColorfulGhostBorderBrush}" />
+            </Style>
+            <Style Selector="^.Solid">
+                <Setter Property="Foreground" Value="{DynamicResource LabelTagColorfulSolidForeground}" />
+                <Setter Property="Background" Value="{DynamicResource LabelTagColorfulSolidBackground}" />
+            </Style>
+            <Style Selector="^.Gradient">
+                <Setter Property="Foreground" Value="{DynamicResource LabelTagColorfulGradientLightForeground}" />
+                <Setter Property="Background" Value="{DynamicResource LabelTagColorfulGradientLightBackground}" />
+                <Style Selector="^.Ghost">
+                    <Setter Property="Foreground" Value="{DynamicResource LabelTagColorfulGradientGhostForeground}" />
+                    <Setter Property="Background" Value="{DynamicResource LabelTagColorfulGradientGhostBackground}" />
+                    <Setter Property="BorderBrush" Value="{DynamicResource LabelTagColorfulGradientGhostBorderBrush}" />
+                </Style>
+                <Style Selector="^.Solid">
+                    <Setter Property="Foreground" Value="{DynamicResource LabelTagColorfulGradientSolidForeground}" />
+                    <Setter Property="Background" Value="{DynamicResource LabelTagColorfulGradientSolidBackground}" />
+                </Style>
+            </Style>
         </Style>
     </ControlTheme>
 </ResourceDictionary>

--- a/src/Semi.Avalonia/Themes/Dark/Label.axaml
+++ b/src/Semi.Avalonia/Themes/Dark/Label.axaml
@@ -88,6 +88,21 @@
     <StaticResource x:Key="LabelTagSolidWhiteBackground" ResourceKey="SemiColorBackground4" />
     <SolidColorBrush x:Key="LabelTagSolidWhiteBorderBrush" Opacity="0.7" Color="{StaticResource SemiGrey2Color}" />
 
+    <StaticResource x:Key="LabelTagColorfulLightForeground" ResourceKey="SemiColorAIPurple" />
+    <StaticResource x:Key="LabelTagColorfulLightBackground" ResourceKey="SemiAIPurple0" />
+    <StaticResource x:Key="LabelTagColorfulGhostForeground" ResourceKey="SemiColorAIPurple" />
+    <StaticResource x:Key="LabelTagColorfulGhostBackground" ResourceKey="SemiColorWhite" />
+    <StaticResource x:Key="LabelTagColorfulGhostBorderBrush" ResourceKey="SemiColorAIPurple" />
+    <StaticResource x:Key="LabelTagColorfulSolidForeground" ResourceKey="SemiColorWhite" />
+    <StaticResource x:Key="LabelTagColorfulSolidBackground" ResourceKey="SemiColorAIPurple" />
+    <StaticResource x:Key="LabelTagColorfulGradientLightForeground" ResourceKey="SemiColorAIGeneral" />
+    <StaticResource x:Key="LabelTagColorfulGradientLightBackground" ResourceKey="SemiAIGeneral0" />
+    <StaticResource x:Key="LabelTagColorfulGradientGhostForeground" ResourceKey="SemiColorAIGeneral" />
+    <StaticResource x:Key="LabelTagColorfulGradientGhostBackground" ResourceKey="SemiColorWhite" />
+    <StaticResource x:Key="LabelTagColorfulGradientGhostBorderBrush" ResourceKey="SemiColorAIGeneral" />
+    <StaticResource x:Key="LabelTagColorfulGradientSolidForeground" ResourceKey="SemiColorWhite" />
+    <StaticResource x:Key="LabelTagColorfulGradientSolidBackground" ResourceKey="SemiColorAIGeneral" />
+
     <!-- Obsolete -->
     <StaticResource x:Key="LabelTagLightWhiteForeground" ResourceKey="LabelTagSolidWhiteForeground" />
     <StaticResource x:Key="LabelTagLightWhiteBackground" ResourceKey="LabelTagSolidWhiteBackground" />

--- a/src/Semi.Avalonia/Themes/Light/Label.axaml
+++ b/src/Semi.Avalonia/Themes/Light/Label.axaml
@@ -88,6 +88,21 @@
     <StaticResource x:Key="LabelTagSolidWhiteBackground" ResourceKey="SemiColorBackground4" />
     <SolidColorBrush x:Key="LabelTagSolidWhiteBorderBrush" Opacity="0.7" Color="{StaticResource SemiGrey2Color}" />
 
+    <StaticResource x:Key="LabelTagColorfulLightForeground" ResourceKey="SemiColorAIPurple" />
+    <StaticResource x:Key="LabelTagColorfulLightBackground" ResourceKey="SemiAIPurple0" />
+    <StaticResource x:Key="LabelTagColorfulGhostForeground" ResourceKey="SemiColorAIPurple" />
+    <StaticResource x:Key="LabelTagColorfulGhostBackground" ResourceKey="SemiColorWhite" />
+    <StaticResource x:Key="LabelTagColorfulGhostBorderBrush" ResourceKey="SemiColorAIPurple" />
+    <StaticResource x:Key="LabelTagColorfulSolidForeground" ResourceKey="SemiColorWhite" />
+    <StaticResource x:Key="LabelTagColorfulSolidBackground" ResourceKey="SemiColorAIPurple" />
+    <StaticResource x:Key="LabelTagColorfulGradientLightForeground" ResourceKey="SemiColorAIGeneral" />
+    <StaticResource x:Key="LabelTagColorfulGradientLightBackground" ResourceKey="SemiAIGeneral0" />
+    <StaticResource x:Key="LabelTagColorfulGradientGhostForeground" ResourceKey="SemiColorAIGeneral" />
+    <StaticResource x:Key="LabelTagColorfulGradientGhostBackground" ResourceKey="SemiColorWhite" />
+    <StaticResource x:Key="LabelTagColorfulGradientGhostBorderBrush" ResourceKey="SemiColorAIGeneral" />
+    <StaticResource x:Key="LabelTagColorfulGradientSolidForeground" ResourceKey="SemiColorWhite" />
+    <StaticResource x:Key="LabelTagColorfulGradientSolidBackground" ResourceKey="SemiColorAIGeneral" />
+
     <!-- Obsolete -->
     <StaticResource x:Key="LabelTagLightWhiteForeground" ResourceKey="LabelTagSolidWhiteForeground" />
     <StaticResource x:Key="LabelTagLightWhiteBackground" ResourceKey="LabelTagSolidWhiteBackground" />

--- a/src/Semi.Avalonia/Themes/Shared/Label.axaml
+++ b/src/Semi.Avalonia/Themes/Shared/Label.axaml
@@ -8,4 +8,5 @@
     <StaticResource x:Key="LabelTagFontWeight" ResourceKey="SemiFontWeightRegular" />
     <StaticResource x:Key="LabelTagSquareCornerRadius" ResourceKey="SemiBorderRadiusSmall" />
     <StaticResource x:Key="LabelTagCircleCornerRadius" ResourceKey="SemiBorderRadiusFull" />
+    <StaticResource x:Key="LabelTagColorfulFontWeight" ResourceKey="SemiFontWeightBold" />
 </ResourceDictionary>


### PR DESCRIPTION
<img width="146" height="101" alt="image" src="https://github.com/user-attachments/assets/ebf62475-5f0a-46e8-8158-00f9b8f83596" />


This pull request introduces a new "AI style" for labels and buttons, focusing on colorful and gradient visual themes. It updates the label and button demos to showcase these new styles, adds the necessary styles and resources to support them in both light and dark themes, and refactors demo layouts for improved clarity and organization.

**AI Style Theme Addition**

* Added new "Colorful" and "Colorful Gradient" label styles, including support for "Ghost" and "Solid" variants, with corresponding style definitions in `Label.axaml`.
* Defined new color and brush resources for "Colorful" and "Colorful Gradient" label styles in both light and dark theme resource files (`src/Semi.Avalonia/Themes/Light/Label.axaml`, `src/Semi.Avalonia/Themes/Dark/Label.axaml`). [[1]](diffhunk://#diff-00e21589b049a0470e2eb6b5adb3186c75afb1d44fcf8a325116f45ae9b76c8eR91-R105) [[2]](diffhunk://#diff-678153f5d835b1e6d3347880cf3e97ab71823a3c1383055355c127c1fd53ba02R91-R105)
* Introduced a bold font weight resource for "Colorful" labels in shared resources (`src/Semi.Avalonia/Themes/Shared/Label.axaml`).

**Demo and Documentation Updates**

* Updated the label and button demo pages to display and organize the new AI style labels and buttons, including grouping examples and updating headers for clarity (`demo/Semi.Avalonia.Demo/Pages/LabelDemo.axaml`, `demo/Semi.Avalonia.Demo/Pages/ButtonDemo.axaml`). [[1]](diffhunk://#diff-e1a3f59ceb2023c6954162b4dc0c53e27a0b96a6ec44baec347c88cc223cd9b5L11-R15) [[2]](diffhunk://#diff-e1a3f59ceb2023c6954162b4dc0c53e27a0b96a6ec44baec347c88cc223cd9b5L159-R163) [[3]](diffhunk://#diff-e1a3f59ceb2023c6954162b4dc0c53e27a0b96a6ec44baec347c88cc223cd9b5L183-R182) [[4]](diffhunk://#diff-e1a3f59ceb2023c6954162b4dc0c53e27a0b96a6ec44baec347c88cc223cd9b5L202-R201) [[5]](diffhunk://#diff-e1a3f59ceb2023c6954162b4dc0c53e27a0b96a6ec44baec347c88cc223cd9b5L221-R238) [[6]](diffhunk://#diff-e25ac444892a456a879aa56a9fb088f2cb2799e2059b1d733233687949765bc5L116-R127)
* Added preview examples for the new AI style labels in the label control preview (`src/Semi.Avalonia/Controls/Label.axaml`).

**Documentation**

* Updated inline documentation to mention the new "AI style: Colorful, Gradient" option in label control theme comments (`src/Semi.Avalonia/Controls/Label.axaml`).
