### PR TITLE
fix: controls under TextBox inheriting Ibeam cursor

### DIFF
--- a/src/Semi.Avalonia/Controls/TextBox.axaml
+++ b/src/Semi.Avalonia/Controls/TextBox.axaml
@@ -260,7 +260,6 @@
         <Setter Property="BorderThickness" Value="{DynamicResource TextBoxBorderThickness}" />
         <Setter Property="BackgroundSizing" Value="OuterBorderEdge" />
         <Setter Property="CornerRadius" Value="{DynamicResource TextBoxDefaultCornerRadius}" />
-        <Setter Property="Cursor" Value="Ibeam" />
         <Setter Property="CaretBrush" Value="{DynamicResource TextBoxTextCaretBrush}" />
         <Setter Property="Padding" Value="{DynamicResource TextBoxContentPadding}" />
         <Setter Property="MinHeight" Value="{DynamicResource TextBoxDefaultHeight}" />
@@ -328,6 +327,11 @@
                                         TextAlignment="{TemplateBinding TextAlignment}"
                                         TextWrapping="{TemplateBinding TextWrapping}" />
                                 </Panel>
+                                <ScrollViewer.Styles>
+                                    <Style Selector="ScrollContentPresenter#PART_ContentPresenter">
+                                        <Setter Property="Cursor" Value="Ibeam" />
+                                    </Style>
+                                </ScrollViewer.Styles>
                             </ScrollViewer>
                             <Button
                                 Name="PART_ClearButton"
@@ -483,7 +487,6 @@
         <Setter Property="Foreground" Value="{DynamicResource TextBoxForeground}" />
         <Setter Property="SelectionBrush" Value="{DynamicResource TextBoxSelectionBackground}" />
         <Setter Property="SelectionForegroundBrush" Value="{DynamicResource TextBoxSelectionForeground}" />
-        <Setter Property="Cursor" Value="Ibeam" />
         <Setter Property="CaretBrush" Value="{DynamicResource TextBoxTextCaretBrush}" />
         <Setter Property="Padding" Value="{DynamicResource TextBoxContentPadding}" />
         <Setter Property="MinHeight" Value="{DynamicResource TextBoxDefaultHeight}" />
@@ -542,6 +545,11 @@
                                     TextAlignment="{TemplateBinding TextAlignment}"
                                     TextWrapping="{TemplateBinding TextWrapping}" />
                             </Panel>
+                            <ScrollViewer.Styles>
+                                <Style Selector="ScrollContentPresenter#PART_ContentPresenter">
+                                    <Setter Property="Cursor" Value="Ibeam" />
+                                </Style>
+                            </ScrollViewer.Styles>
                         </ScrollViewer>
                         <ContentPresenter
                             Grid.Column="2"


### PR DESCRIPTION
#653 Apply to all themes