### PR TITLE
fix: ClearButton shouble not be focusable

### DIFF
--- a/src/Semi.Avalonia/Controls/DatePicker.axaml
+++ b/src/Semi.Avalonia/Controls/DatePicker.axaml
@@ -239,7 +239,8 @@
                             Margin="0,0,9,0"
                             Command="{Binding $parent[DatePicker].Clear}"
                             Content="{DynamicResource IconButtonClearData}"
-                            IsVisible="False" />
+                            IsVisible="False"
+                            Focusable="False" />
                     </Grid>
                 </DataValidationErrors>
             </ControlTemplate>

--- a/src/Semi.Avalonia/Controls/TextBox.axaml
+++ b/src/Semi.Avalonia/Controls/TextBox.axaml
@@ -107,6 +107,7 @@
                                 Command="{Binding $parent[TextBox].Clear}"
                                 Content="{DynamicResource IconButtonClearData}"
                                 IsVisible="False"
+                                Focusable="False"
                                 Theme="{StaticResource InnerIconButton}" />
                             <ToggleButton
                                 Name="PART_RevealButton"
@@ -339,6 +340,7 @@
                                 Command="{Binding $parent[TextBox].Clear}"
                                 Content="{DynamicResource IconButtonClearData}"
                                 IsVisible="False"
+                                Focusable="False"
                                 Theme="{StaticResource InnerIconButton}" />
                             <ToggleButton
                                 Name="PART_RevealButton"

--- a/src/Semi.Avalonia/Controls/TimePicker.axaml
+++ b/src/Semi.Avalonia/Controls/TimePicker.axaml
@@ -305,7 +305,8 @@
                             Margin="0,0,9,0"
                             Command="{Binding $parent[TimePicker].Clear}"
                             Content="{DynamicResource IconButtonClearData}"
-                            IsVisible="False" />
+                            IsVisible="False"
+                            Focusable="False" />
                     </Grid>
                 </DataValidationErrors>
             </ControlTemplate>


### PR DESCRIPTION
Set `Focusable="False"` on the clear button in  `TextBox`, `TimePicker` , `DatePicker` to prevent it from receiving keyboard focus.