### PR TITLE
feat: add Inter font resource reference to SemiFontFamilyRegular

### DIFF
--- a/src/Semi.Avalonia/Tokens/Variables.axaml
+++ b/src/Semi.Avalonia/Tokens/Variables.axaml
@@ -67,7 +67,7 @@
     <FontWeight x:Key="SemiFontWeightRegular">400</FontWeight> <!-- 字重 - 常规 -->
     <FontWeight x:Key="SemiFontWeightBold">600</FontWeight> <!-- 字重 - 粗 -->
     <FontFamily x:Key="SemiFontFamilyRegular">
-        Inter, -apple-system, BlinkMacSystemFont, PingFang SC,
+        fonts:Inter#Inter, Inter, -apple-system, BlinkMacSystemFont, PingFang SC,
         Microsoft YaHei, Segoe UI, Hiragino Sans GB, Helvetica Neue,
         Helvetica, Arial, sans-serif
     </FontFamily>


### PR DESCRIPTION
Semi.Avalonia currently references the font family as `Inter`, which only works
when the font is installed system-wide.

This change switches to `fonts:Inter#Inter`, allowing Semi.Avalonia to
automatically use the Inter font when the Avalonia.Fonts.Inter package (https://github.com/AvaloniaUI/Avalonia/tree/master/src/Avalonia.Fonts.Inter) is
referenced, without requiring a system-installed font.