### PR TITLE
Sync upstream update

### DIFF
--- a/src/Semi.Avalonia/Controls/SplitView.axaml
+++ b/src/Semi.Avalonia/Controls/SplitView.axaml
@@ -52,7 +52,7 @@
             <Style Selector="^:overlay">
                 <Style Selector="^ /template/ Panel#PART_PaneRoot">
                     <Setter Property="Width" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ClosedPaneWidth}" />
-                    <Setter Property="Grid.ColumnSpan" Value="1" />
+                    <Setter Property="Grid.ColumnSpan" Value="2" />
                     <Setter Property="Grid.Column" Value="0" />
                 </Style>
                 <Style Selector="^ /template/ Panel#ContentRoot">
@@ -75,8 +75,7 @@
 
             <Style Selector="^:compactoverlay">
                 <Style Selector="^ /template/ Panel#PART_PaneRoot">
-                    <!--  ColumnSpan should be 2  -->
-                    <Setter Property="Grid.ColumnSpan" Value="1" />
+                    <Setter Property="Grid.ColumnSpan" Value="2" />
                     <Setter Property="Grid.Column" Value="0" />
                     <Setter Property="Width" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ClosedPaneWidth}" />
                 </Style>

--- a/src/Semi.Avalonia/Controls/TabControl.axaml
+++ b/src/Semi.Avalonia/Controls/TabControl.axaml
@@ -36,13 +36,19 @@
                                 ItemsPanel="{TemplateBinding ItemsPanel}" />
                             <Border Name="PART_BorderSeparator" />
                         </Panel>
-                        <ContentPresenter
-                            Name="PART_SelectedContentHost"
-                            Margin="{TemplateBinding Padding}"
-                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Content="{TemplateBinding SelectedContent}"
-                            ContentTemplate="{TemplateBinding SelectedContentTemplate}" />
+                        <Panel ClipToBounds="True">
+                            <ContentPresenter 
+                                Name="PART_SelectedContentHost2"
+                                Margin="{TemplateBinding Padding}"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                IsVisible="False" />
+                            <ContentPresenter
+                                Name="PART_SelectedContentHost"
+                                Margin="{TemplateBinding Padding}"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+                        </Panel>
                     </DockPanel>
                 </Border>
             </ControlTemplate>


### PR DESCRIPTION
This pull request makes adjustments to the layout logic in the `SplitView` and `TabControl` controls, primarily to improve how content is displayed and managed in overlay modes and tab selection. The changes focus on correcting column spanning in overlay modes and reorganizing content presenters for better control and visibility handling.

Layout adjustments for `SplitView` overlay modes:

* Changed the `Grid.ColumnSpan` property from `1` to `2` for `Panel#PART_PaneRoot` in both `:overlay` and `:compactoverlay` styles, ensuring the pane occupies the correct number of columns in overlay modes. [[1]](diffhunk://#diff-8bf3bf95cda2f37d3c3a66d4bd63375023234588a6713084588bb63a03265d77L55-R55) [[2]](diffhunk://#diff-8bf3bf95cda2f37d3c3a66d4bd63375023234588a6713084588bb63a03265d77L78-R78)

Content presenter improvements in `TabControl`:

* Added a new `Panel` containing two `ContentPresenter` elements: `PART_SelectedContentHost2` (now hidden by default) and `PART_SelectedContentHost`, reorganizing the template to allow for more flexible content hosting and visibility management.