### PR TITLE
fix: add icons to TabbedPage content and improve layout.

### DIFF
--- a/demo/Semi.Avalonia.Demo/Pages/TabbedPageDemo.axaml
+++ b/demo/Semi.Avalonia.Demo/Pages/TabbedPageDemo.axaml
@@ -50,7 +50,7 @@
             <TabbedPage Name="DemoTabs"
                         TabPlacement="Top"
                         SelectionChanged="OnSelectionChanged">
-                <ContentPage Header="Home">
+                <ContentPage Icon="{DynamicResource SemiIconHome}" Header="Home">
                     <StackPanel Margin="16" Spacing="8">
                         <TextBlock Text="Home Tab" FontSize="24" FontWeight="Bold" />
                         <TextBlock Text="Welcome to the Home tab. This is a TabbedPage sample."
@@ -59,14 +59,14 @@
                                    TextWrapping="Wrap" Opacity="0.7" />
                     </StackPanel>
                 </ContentPage>
-                <ContentPage Header="Search">
+                <ContentPage Icon="{DynamicResource SemiIconSearch}" Header="Search">
                     <StackPanel Margin="16" Spacing="8">
                         <TextBlock Text="Search Tab" FontSize="24" FontWeight="Bold" />
                         <TextBox PlaceholderText="Type to search..." />
                         <TextBlock Text="Search results will appear here." Opacity="0.7" />
                     </StackPanel>
                 </ContentPage>
-                <ContentPage Header="Settings">
+                <ContentPage Icon="{DynamicResource SemiIconSetting}" Header="Settings">
                     <StackPanel Margin="16" Spacing="8">
                         <TextBlock Text="Settings Tab" FontSize="24" FontWeight="Bold" />
                         <CheckBox Content="Enable notifications" />

--- a/src/Semi.Avalonia/Controls/TabItem.axaml
+++ b/src/Semi.Avalonia/Controls/TabItem.axaml
@@ -31,7 +31,6 @@
                     <DockPanel HorizontalSpacing="{DynamicResource TabItemIconHeaderSpacing}">
                         <ContentPresenter
                             Name="PART_IconPresenter"
-                            DockPanel.Dock="Left"
                             Content="{TemplateBinding Icon}"
                             ContentTemplate="{TemplateBinding IconTemplate}"
                             IsVisible="{Binding $self.Content, Converter={x:Static ObjectConverters.IsNotNull}}">
@@ -59,6 +58,10 @@
 
         <Style Selector="^ /template/ ContentPresenter#PART_HeaderPresenter">
             <Setter Property="RecognizesAccessKey" Value="True" />
+        </Style>
+
+        <Style Selector="^ /template/ ContentPresenter#PART_IconPresenter">
+            <Setter Property="DockPanel.Dock" Value="Left" />
         </Style>
 
         <Style Selector="^:selected">

--- a/src/Semi.Avalonia/Controls/TabbedPage.axaml
+++ b/src/Semi.Avalonia/Controls/TabbedPage.axaml
@@ -2,7 +2,11 @@
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
-        <TabbedPage Width="400" Height="300" />
+        <TabbedPage Width="400" Height="800" TabPlacement="Bottom">
+            <ContentPage Icon="{DynamicResource SemiIconHome}" Header="Home" />
+            <ContentPage Icon="{DynamicResource SemiIconSearch}" Header="Search" />
+            <ContentPage Icon="{DynamicResource SemiIconSetting}" Header="Settings" />
+        </TabbedPage>
     </Design.PreviewWith>
 
     <ControlTheme x:Key="{x:Type TabbedPage}" TargetType="TabbedPage">
@@ -11,27 +15,92 @@
                 <TabControl
                     Name="PART_TabControl"
                     Background="{TemplateBinding Background}"
-                    Theme="{StaticResource LineTabControl}" />
+                    Theme="{StaticResource LineTabControl}">
+                    <TabControl.ItemContainerTheme>
+                        <ControlTheme
+                            BasedOn="{StaticResource LineTabItem}"
+                            TargetType="TabItem">
+                            <Setter Property="HorizontalContentAlignment" Value="Center" />
+                            <Setter Property="VerticalContentAlignment" Value="Center" />
+                            <Style Selector="^ /template/ ContentPresenter#PART_IconPresenter">
+                                <Setter Property="DockPanel.Dock" Value="Top" />
+                            </Style>
+                            <Style Selector="^[TabStripPlacement=Top], ^[TabStripPlacement=Bottom]">
+                                <Setter Property="TabItem.Margin" Value="0" />
+                            </Style>
+                        </ControlTheme>
+                    </TabControl.ItemContainerTheme>
+                    <TabControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <UniformGrid Columns="{Binding $parent[TabControl].ItemCount}" />
+                        </ItemsPanelTemplate>
+                    </TabControl.ItemsPanel>
+                </TabControl>
             </ControlTemplate>
         </Setter>
     </ControlTheme>
+
     <ControlTheme x:Key="CardTabbedPage" TargetType="TabbedPage">
         <Setter Property="Template">
             <ControlTemplate TargetType="TabbedPage">
                 <TabControl
                     Name="PART_TabControl"
                     Background="{TemplateBinding Background}"
-                    Theme="{StaticResource CardTabControl}" />
+                    Theme="{StaticResource CardTabControl}">
+                    <TabControl.ItemContainerTheme>
+                        <ControlTheme
+                            BasedOn="{StaticResource CardTabItem}"
+                            TargetType="TabItem">
+                            <Setter Property="HorizontalContentAlignment" Value="Center" />
+                            <Setter Property="VerticalContentAlignment" Value="Center" />
+                            <Style Selector="^ /template/ ContentPresenter#PART_IconPresenter">
+                                <Setter Property="DockPanel.Dock" Value="Top" />
+                            </Style>
+                            <Style Selector="^[TabStripPlacement=Top], ^[TabStripPlacement=Bottom]">
+                                <Setter Property="TabItem.Padding" Value="8" />
+                                <Setter Property="TabItem.Margin" Value="0" />
+                            </Style>
+                        </ControlTheme>
+                    </TabControl.ItemContainerTheme>
+                    <TabControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <UniformGrid Columns="{Binding $parent[TabControl].ItemCount}" />
+                        </ItemsPanelTemplate>
+                    </TabControl.ItemsPanel>
+                </TabControl>
             </ControlTemplate>
         </Setter>
     </ControlTheme>
+
     <ControlTheme x:Key="ButtonTabbedPage" TargetType="TabbedPage">
         <Setter Property="Template">
             <ControlTemplate TargetType="TabbedPage">
                 <TabControl
                     Name="PART_TabControl"
                     Background="{TemplateBinding Background}"
-                    Theme="{StaticResource ButtonTabControl}" />
+                    Theme="{StaticResource ButtonTabControl}">
+                    <TabControl.ItemContainerTheme>
+                        <ControlTheme
+                            BasedOn="{StaticResource ButtonTabItem}"
+                            TargetType="TabItem">
+                            <Setter Property="Padding" Value="8 0" />
+                            <Setter Property="HorizontalContentAlignment" Value="Center" />
+                            <Setter Property="VerticalContentAlignment" Value="Center" />
+                            <Style Selector="^ /template/ ContentPresenter#PART_IconPresenter">
+                                <Setter Property="DockPanel.Dock" Value="Top" />
+                            </Style>
+                            <Style Selector="^[TabStripPlacement=Top], ^[TabStripPlacement=Bottom]">
+                                <Setter Property="TabItem.Padding" Value="12" />
+                                <Setter Property="TabItem.Margin" Value="0" />
+                            </Style>
+                        </ControlTheme>
+                    </TabControl.ItemContainerTheme>
+                    <TabControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <UniformGrid Columns="{Binding $parent[TabControl].ItemCount}" />
+                        </ItemsPanelTemplate>
+                    </TabControl.ItemsPanel>
+                </TabControl>
             </ControlTemplate>
         </Setter>
     </ControlTheme>

--- a/src/Semi.Avalonia/Controls/TabbedPage.axaml
+++ b/src/Semi.Avalonia/Controls/TabbedPage.axaml
@@ -20,13 +20,13 @@
                         <ControlTheme
                             BasedOn="{StaticResource LineTabItem}"
                             TargetType="TabItem">
-                            <Setter Property="HorizontalContentAlignment" Value="Center" />
-                            <Setter Property="VerticalContentAlignment" Value="Center" />
-                            <Style Selector="^ /template/ ContentPresenter#PART_IconPresenter">
-                                <Setter Property="DockPanel.Dock" Value="Top" />
-                            </Style>
                             <Style Selector="^[TabStripPlacement=Top], ^[TabStripPlacement=Bottom]">
                                 <Setter Property="TabItem.Margin" Value="0" />
+                                <Setter Property="TabItem.HorizontalContentAlignment" Value="Center" />
+                                <Setter Property="TabItem.VerticalContentAlignment" Value="Center" />
+                                <Style Selector="^ /template/ ContentPresenter#PART_IconPresenter">
+                                    <Setter Property="DockPanel.Dock" Value="Top" />
+                                </Style>
                             </Style>
                         </ControlTheme>
                     </TabControl.ItemContainerTheme>
@@ -51,14 +51,14 @@
                         <ControlTheme
                             BasedOn="{StaticResource CardTabItem}"
                             TargetType="TabItem">
-                            <Setter Property="HorizontalContentAlignment" Value="Center" />
-                            <Setter Property="VerticalContentAlignment" Value="Center" />
-                            <Style Selector="^ /template/ ContentPresenter#PART_IconPresenter">
-                                <Setter Property="DockPanel.Dock" Value="Top" />
-                            </Style>
                             <Style Selector="^[TabStripPlacement=Top], ^[TabStripPlacement=Bottom]">
                                 <Setter Property="TabItem.Padding" Value="8" />
                                 <Setter Property="TabItem.Margin" Value="0" />
+                                <Setter Property="TabItem.HorizontalContentAlignment" Value="Center" />
+                                <Setter Property="TabItem.VerticalContentAlignment" Value="Center" />
+                                <Style Selector="^ /template/ ContentPresenter#PART_IconPresenter">
+                                    <Setter Property="DockPanel.Dock" Value="Top" />
+                                </Style>
                             </Style>
                         </ControlTheme>
                     </TabControl.ItemContainerTheme>
@@ -83,15 +83,14 @@
                         <ControlTheme
                             BasedOn="{StaticResource ButtonTabItem}"
                             TargetType="TabItem">
-                            <Setter Property="Padding" Value="8 0" />
-                            <Setter Property="HorizontalContentAlignment" Value="Center" />
-                            <Setter Property="VerticalContentAlignment" Value="Center" />
-                            <Style Selector="^ /template/ ContentPresenter#PART_IconPresenter">
-                                <Setter Property="DockPanel.Dock" Value="Top" />
-                            </Style>
                             <Style Selector="^[TabStripPlacement=Top], ^[TabStripPlacement=Bottom]">
                                 <Setter Property="TabItem.Padding" Value="12" />
                                 <Setter Property="TabItem.Margin" Value="0" />
+                                <Setter Property="TabItem.HorizontalContentAlignment" Value="Center" />
+                                <Setter Property="TabItem.VerticalContentAlignment" Value="Center" />
+                                <Style Selector="^ /template/ ContentPresenter#PART_IconPresenter">
+                                    <Setter Property="DockPanel.Dock" Value="Top" />
+                                </Style>
                             </Style>
                         </ControlTheme>
                     </TabControl.ItemContainerTheme>


### PR DESCRIPTION
This pull request enhances the visual appearance and consistency of tabbed navigation in the application by improving icon support and layout for `TabbedPage` and `TabItem` controls. The main changes include adding icons to tabs, aligning icons and headers, and updating the tab themes to provide a more polished and uniform look across different tab styles.

**TabbedPage and TabItem Visual Improvements:**

* Added icon support to `ContentPage` tabs in both the demo (`TabbedPageDemo.axaml`) and the design preview (`TabbedPage.axaml`), using dynamic resources for standard icons such as Home, Search, and Settings. [[1]](diffhunk://#diff-e3684a76143b74759622c5bbb96d50eab27d9f01d74d059a188ccbbfa42bf2edL53-R53) [[2]](diffhunk://#diff-e3684a76143b74759622c5bbb96d50eab27d9f01d74d059a188ccbbfa42bf2edL62-R69) [[3]](diffhunk://#diff-58b0a5ed79efc1491854cad65a90c676bd9673c71d9a12832aa12a2f11af6eccL5-R9)
* Updated the `TabItem` control template to move the icon alignment styling into a dedicated style, ensuring the icon is docked to the left only when content is present. [[1]](diffhunk://#diff-ee8d57a4f943c5e9e11bb21617e33888c75adc3156781ec90e0d12ee4912b74dL34) [[2]](diffhunk://#diff-ee8d57a4f943c5e9e11bb21617e33888c75adc3156781ec90e0d12ee4912b74dR63-R66)

**TabbedPage Theme and Layout Enhancements:**

* Enhanced all three main tabbed page themes (`LineTabControl`, `CardTabControl`, `ButtonTabControl`) to:
  - Center tab content vertically and horizontally.
  - Dock icons to the top of the tab when the tab strip is at the top or bottom.
  - Use a `UniformGrid` for tab layout, ensuring tabs are evenly spaced.
  - Adjust padding and margin for consistent appearance.
<img width="398" height="142" alt="image" src="https://github.com/user-attachments/assets/93dd2e99-88bc-4bd0-a532-eb088a75a679" />
<img width="396" height="86" alt="image" src="https://github.com/user-attachments/assets/a698a167-e380-4545-95af-024bbad189ed" />
<img width="398" height="128" alt="image" src="https://github.com/user-attachments/assets/01559d5c-b52d-4f5c-be96-a339c1ca037a" />

